### PR TITLE
Issue#28 peak 'start' and 'end' must differ by at least 1bp

### DIFF
--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -49,6 +49,11 @@ where:
 * ``chrom`` is the chromosome that the peak appears on
 * ``start`` and ``end`` define the limits of the peak region
 
+.. warning::
+
+   ``start`` and ``end`` positions must differ by at least 1bp,
+   and the ``end`` must come after the ``start``.
+
 Any additional columns found in the file are ignored.
 
 .. note::

--- a/rnachipintegrator/Peaks.py
+++ b/rnachipintegrator/Peaks.py
@@ -251,6 +251,9 @@ class Peak:
         if self.start == self.end:
             raise PeakRangeError("'start' and 'end' positions should "
                                  "differ by at least 1bp")
+        elif self.end < self.start:
+            raise PeakRangeError("'end' position must not come before "
+                                 "'start'")
 
     def __repr__(self):
         return "%s\t%s\t%s" % (self.chrom,

--- a/rnachipintegrator/Peaks.py
+++ b/rnachipintegrator/Peaks.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     Peaks.py: classes for handling peak data
-#     Copyright (C) University of Manchester 2011-15 Peter Briggs, Leo Zeef
+#     Copyright (C) University of Manchester 2011-16 Peter Briggs, Leo Zeef
 #     & Ian Donaldson
 #
 """
@@ -85,23 +85,25 @@ class PeakSet:
             if not items[start].isdigit() or not items[end].isdigit():
                 logging.warning("Peaks file: skipped line: %s" % line.strip())
                 # Indicate problem field(s)
-                errline = []
-                for i in range(len(items)):
-                    if i == start or i == end:
-                        if not items[i].isdigit():
-                            errline.append("^"*len(items[i]))
-                        else:
-                            errline.append(" "*len(items[i]))
-                    else:
-                        errline.append(" "*len(items[i]))
+                bad_fields = []
+                for i in (start,end):
+                    if not items[i].isdigit():
+                        bad_fields.append(i)
                 logging.warning("                         %s" % \
-                                    ('\t'.join(errline)))
+                                make_errline(line,bad_fields))
                 logging.warning("Expected integer at indicated positions")
                 continue
             # Store in a new Peak object
-            peak = Peak(items[chrom],
-                        items[start],
-                        items[end])
+            try:
+                peak = Peak(items[chrom],
+                            items[start],
+                            items[end])
+            except PeakRangeError,ex:
+                logging.error("Peaks file: bad line: %s" % line.strip())
+                logging.error("                      %s" %
+                              make_errline(line,(start,end)))
+                logging.error("%s" % ex)
+                raise ex
             self.peaks.append(peak)
         fp.close()
         # Return a reference to this object
@@ -238,11 +240,17 @@ class Peak:
 
     There are also convenience methods (e.g. insideRegion).
 
+    Raises a PeakRangeError exception if the peak start and end
+    positions don't differ by at least 1bp.
+
     """
     def __init__(self,chrom,start,end):
         self.chrom = chrom.strip('"\'')
         self.start = int(start)
         self.end = int(end)
+        if self.start == self.end:
+            raise PeakRangeError("'start' and 'end' positions should "
+                                 "differ by at least 1bp")
 
     def __repr__(self):
         return "%s\t%s\t%s" % (self.chrom,
@@ -285,3 +293,8 @@ class Peak:
             return (lower <= self.start and self.start <= upper)
         else:
             return (lower < self.start and self.start < upper)
+
+class PeakRangeError(ValueError):
+    """
+    Class for raising errors with peak start/end ranges
+    """

--- a/rnachipintegrator/cli.py
+++ b/rnachipintegrator/cli.py
@@ -276,7 +276,12 @@ def main(args=None):
     # Read in peak data
     print "Using columns %s from peaks file as chrom, start, end" % \
         (peak_cols,)
-    peaks = PeakSet(peak_file,columns=peak_cols)
+    try:
+        peaks = PeakSet(peak_file,columns=peak_cols)
+    except Exception,ex:
+        logging.critical("Failed to read peak data (%s)" % ex)
+        print "Please fix errors in input file before running again"
+        sys.exit(1)
     if not len(peaks):
         logging.error("No peak data read in")
         sys.exit(1)

--- a/rnachipintegrator/utils.py
+++ b/rnachipintegrator/utils.py
@@ -39,7 +39,7 @@ def make_errline(line,bad_fields=[]):
     """
     # Indicate problem field(s)
     errline = []
-    items = line.split('\t')
+    items = line.rstrip().split('\t')
     for i in range(len(items)):
         if i in bad_fields:
             errline.append("^"*len(items[i]))

--- a/test/common.py
+++ b/test/common.py
@@ -135,6 +135,13 @@ chip_peaks_ex5 = \
 "chr4"	107209680	107211432
 "chr12"	28921259	28923030"""
 #
+# ChIP_peaks-ex6.txt (same start/end position)
+chip_peaks_ex6 = \
+"""chr2L	66811	66812
+chr2L	8825470	8825470
+chr2L	8832523	8832524
+chr2L	8842036	8842037"""
+#
 # NearestTranscriptToPeak-ex3.txt
 nearest_transcript_to_peak_ex3 = \
 """#chr	start	geneID	nearest	TSS	distance_to_TSS	distance_to_TES	strand	in_the_gene	transcripts_inbetween	transcript_ids_inbetween

--- a/test/common.py
+++ b/test/common.py
@@ -142,6 +142,13 @@ chr2L	8825470	8825470
 chr2L	8832523	8832524
 chr2L	8842036	8842037"""
 #
+# ChIP_peaks-ex7.txt (end position before start)
+chip_peaks_ex7 = \
+"""chr2L	66811	66812
+chr2L	8825470	8825471
+chr2L	8832524	8832523
+chr2L	8842036	8842037"""
+#
 # NearestTranscriptToPeak-ex3.txt
 nearest_transcript_to_peak_ex3 = \
 """#chr	start	geneID	nearest	TSS	distance_to_TSS	distance_to_TES	strand	in_the_gene	transcripts_inbetween	transcript_ids_inbetween

--- a/test/test_Peaks.py
+++ b/test/test_Peaks.py
@@ -1,10 +1,11 @@
 #
 #     test_Peaks.py: unit tests for Peaks module
-#     Copyright (C) University of Manchester 2011-5 Peter Briggs
+#     Copyright (C) University of Manchester 2011-6 Peter Briggs
 
 from common import *
 from rnachipintegrator.Peaks import PeakSet
 from rnachipintegrator.Peaks import Peak
+from rnachipintegrator.Peaks import PeakRangeError
 from rnachipintegrator.Features import FeatureSet
 from rnachipintegrator.distances import GetNearestTranscriptToPeak
 import unittest
@@ -16,6 +17,7 @@ class TestPeakSet(unittest.TestCase):
         create_test_file('ChIP_peaks-ex1.txt',chip_peaks_ex1)
         create_test_file('ChIP_peaks-ex2.txt',chip_peaks_ex2)
         create_test_file('ChIP_peaks-ex5.txt',chip_peaks_ex5)
+        create_test_file('ChIP_peaks-ex6.txt',chip_peaks_ex6)
         create_test_file('ChIP_peaks_multi_columns-ex1.txt',
                          chip_peaks_multi_columns_ex1)
 
@@ -24,6 +26,7 @@ class TestPeakSet(unittest.TestCase):
         delete_test_file('ChIP_peaks-ex1.txt')
         delete_test_file('ChIP_peaks-ex2.txt')
         delete_test_file('ChIP_peaks-ex5.txt')
+        delete_test_file('ChIP_peaks-ex6.txt')
 
     def test_reading_in_ChIPseq_data(self):
         peaks = PeakSet('ChIP_peaks-ex1.txt')
@@ -55,6 +58,9 @@ class TestPeakSet(unittest.TestCase):
         self.assertEqual(peaks[0],Peak('chr2L',66711,66911))
         self.assertEqual(peaks[1],Peak('chr2L',605850,606050))
         self.assertEqual(peaks[2],Peak('chr3L',2258089,2258289))
+
+    def test_fail_when_peak_start_and_end_are_equal(self):
+        self.assertRaises(PeakRangeError,PeakSet,'ChIP_peaks-ex6.txt')
 
     def test_is_summit_data(self):
         peaks = PeakSet('ChIP_peaks-ex1.txt')
@@ -162,6 +168,8 @@ class TestPeak(unittest.TestCase):
                          Peak('chr2L','66811','66812'))
         self.assertNotEqual(Peak('chr2L','66811','66812'),
                             Peak('chr2L','249177','605951'))
+    def test_peak_start_and_end_are_equal(self):
+        self.assertRaises(PeakRangeError,Peak,'chr2L','66811','66811')
 
 class TestFeatureSetWithChIPSeqData(unittest.TestCase):
     def setUp(self):

--- a/test/test_Peaks.py
+++ b/test/test_Peaks.py
@@ -18,6 +18,7 @@ class TestPeakSet(unittest.TestCase):
         create_test_file('ChIP_peaks-ex2.txt',chip_peaks_ex2)
         create_test_file('ChIP_peaks-ex5.txt',chip_peaks_ex5)
         create_test_file('ChIP_peaks-ex6.txt',chip_peaks_ex6)
+        create_test_file('ChIP_peaks-ex7.txt',chip_peaks_ex7)
         create_test_file('ChIP_peaks_multi_columns-ex1.txt',
                          chip_peaks_multi_columns_ex1)
 
@@ -27,6 +28,7 @@ class TestPeakSet(unittest.TestCase):
         delete_test_file('ChIP_peaks-ex2.txt')
         delete_test_file('ChIP_peaks-ex5.txt')
         delete_test_file('ChIP_peaks-ex6.txt')
+        delete_test_file('ChIP_peaks-ex7.txt')
 
     def test_reading_in_ChIPseq_data(self):
         peaks = PeakSet('ChIP_peaks-ex1.txt')
@@ -61,6 +63,9 @@ class TestPeakSet(unittest.TestCase):
 
     def test_fail_when_peak_start_and_end_are_equal(self):
         self.assertRaises(PeakRangeError,PeakSet,'ChIP_peaks-ex6.txt')
+
+    def test_fail_when_peak_end_is_before_start(self):
+        self.assertRaises(PeakRangeError,PeakSet,'ChIP_peaks-ex7.txt')
 
     def test_is_summit_data(self):
         peaks = PeakSet('ChIP_peaks-ex1.txt')
@@ -170,6 +175,8 @@ class TestPeak(unittest.TestCase):
                             Peak('chr2L','249177','605951'))
     def test_peak_start_and_end_are_equal(self):
         self.assertRaises(PeakRangeError,Peak,'chr2L','66811','66811')
+    def test_peak_end_before_start(self):
+        self.assertRaises(PeakRangeError,Peak,'chr2L','66812','66811')
 
 class TestFeatureSetWithChIPSeqData(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
PR to address issue #28 (stop with error if peak 'start' and 'end' positions are equal).