### PR TITLE
Fix crash when using zero cutoff with --xlsx (issue #41)

### DIFF
--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -88,6 +88,7 @@ echo "'Compact' test: OK"
 # Check --cutoff=0 works
 RnaChipIntegrator --name=zero_cutoff \
     --cutoff=0 \
+    --xlsx \
     $TEST_DIR/ExpressionData.txt \
     $TEST_DIR/ChIP_regions.txt
 if [ $? -ne 0 ] ; then

--- a/rnachipintegrator/cli.py
+++ b/rnachipintegrator/cli.py
@@ -370,7 +370,11 @@ def main(args=None):
         xlsx.append_to_notes("Input %ss file\t%s" % (feature_type,
                                                      gene_file))
         xlsx.append_to_notes("Input peaks file\t%s" % peak_file)
-        xlsx.append_to_notes("Maximum cutoff distance (bp)\t%d" % max_distance)
+        if max_distance is not None:
+            xlsx.append_to_notes("Maximum cutoff distance (bp)\t%d" %
+                                 max_distance)
+        else:
+            xlsx.append_to_notes("Maximum cutoff distance (bp)\tno cutoff")
         xlsx.append_to_notes("Maximum no. of hits to report\t%s"
                              % ('All' if max_closest is None
                                 else "%d" % max_closest))


### PR DESCRIPTION
PR to fix crash when `--cutoff=0` is used in combination with `--xlsx` (issue #41).