### PR TITLE
Issue 40: clarify up and downstream terminology in output

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -44,8 +44,8 @@ dist_closest	 closest distance between peak and gene considering
                  all edges (zero if there is overlap)
 dist_TSS	 distance between peak and gene TSS
 dist_TES	 distance between peak and gene TES
-direction        'U' if hit is upstream, 'D' if downstream, '.' if
-                 overlapped
+direction        'U' if peak is upstream (5') of gene; 'D' if peak
+                 is downstream (3') of gene; '.' if overlapping
 overlap_gene	 1 if peak overlaps the gene, 0 if not
 overlap_promoter 1 if peak overlaps the promoter region, 0 if not
 ================ ================================================

--- a/rnachipintegrator/output.py
+++ b/rnachipintegrator/output.py
@@ -44,7 +44,7 @@ FIELDS = {
     'overlap_feature': "1 if peak overlaps the feature, 0 if not",
     'overlap_promoter': "1 if peak overlaps the promoter region, 0 if not",
     'in_the_feature': "'YES' if peak overlaps the feature, 'NO' if not",
-    'direction': "'U' if peak is upstream (5') of gene; 'D' if peak is downstream (3') of gene; '.' if overlapping",
+    'direction': "'U' if peak is upstream (5') of feature; 'D' if peak is downstream (3') of feature; '.' if overlapping",
     'differentially_expressed': "1 if feature is differentially expressed, 0 if not",
     'order': "the 'order' of the feature/peak pair (e.g. '1 of 4')",
     'number_of_results': "number of hits being reported",

--- a/rnachipintegrator/output.py
+++ b/rnachipintegrator/output.py
@@ -44,7 +44,7 @@ FIELDS = {
     'overlap_feature': "1 if peak overlaps the feature, 0 if not",
     'overlap_promoter': "1 if peak overlaps the promoter region, 0 if not",
     'in_the_feature': "'YES' if peak overlaps the feature, 'NO' if not",
-    'direction': "'U' if hit is upstream, 'D' if downstream, '.' if overlapped",
+    'direction': "'U' if peak is upstream (5') of gene; 'D' if peak is downstream (3') of gene; '.' if overlapping",
     'differentially_expressed': "1 if feature is differentially expressed, 0 if not",
     'order': "the 'order' of the feature/peak pair (e.g. '1 of 4')",
     'number_of_results': "number of hits being reported",


### PR DESCRIPTION
PR to address issue #40 by updating the description of the `direction` field in the outputs, to clarify the meaning of the terms "upstream" and "downstream".