### PR TITLE
Fix bug where 'find_nearest_peaks' drops valid peaks from results (issue #59)

### DIFF
--- a/rnachipintegrator/analysis.py
+++ b/rnachipintegrator/analysis.py
@@ -101,6 +101,13 @@ def find_nearest_peaks(features,peaks,distance=None,tss_only=False,
         FeatureSet
 
     """
+    # Set functions according to edges
+    if tss_only:
+        sort_peaks = sort_peaks_by_tss_distances
+        get_distance = distances.distance_tss
+    else:
+        sort_peaks = sort_peaks_by_edge_distances
+        get_distance = distances.distance_closest_edge
     # Reduce to set of differentially expressed features
     if only_differentially_expressed:
         features = features.filterByFlag(1)
@@ -109,15 +116,12 @@ def find_nearest_peaks(features,peaks,distance=None,tss_only=False,
         # Only consider peaks on same chromosome
         peak_list = peaks.filterByChr(feature.chrom)
         # Sort into distance order
-        if tss_only:
-            sort_peaks_by_tss_distances(feature,peak_list)
-        else:
-            sort_peaks_by_edge_distances(feature,peak_list)
+        sort_peaks(feature,peak_list)
         # Apply distance cut-off
         if distance is not None:
             closest = PeakSet()
             for peak in peak_list:
-                if distances.distance_tss(peak,feature) > distance:
+                if get_distance(peak,feature) > distance:
                     break
                 closest.addPeak(peak)
             peak_list = closest

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1571,3 +1571,29 @@ class TestFindNearestPeaksForRegions(unittest.TestCase):
         expected = PeakSet()
         expected.addPeak(peaks_[2])
         self.assertEqual(peaks,expected)
+
+    def test_find_nearest_peaks_regions_inside_feature_with_distance_cutoff(self):
+        # Set up feature data
+        self.features = FeatureSet()
+        self.features.addFeature(Feature('ENSG00000170776',
+                                         'chr15',
+                                         '85923802',
+                                         '86292586',
+                                         '+'))
+        # Set up peak data
+        self.peaks = PeakSet()
+        for region in (('85874449','85874837'),
+                       ('85956796','85956966'),
+                       ('86021073','86021230'),
+                       ('86106704','86106936')):
+            self.peaks.addPeak(Peak('chr15',region[0],region[1]))
+        # Run the analysis
+        results = list(find_nearest_peaks(self.features,
+                                          self.peaks,
+                                          distance=50000))
+        # Correct number of results (one gene)
+        self.assertEqual(len(results),1)
+        # Check list of peaks
+        # nb result is tuple (feature,peaks)
+        peaks = results[0][1]
+        self.assertEqual(len(peaks),4)


### PR DESCRIPTION
PR to detect and fix bug reported in issue #59, where valid peaks are dropped from the results in the gene-centric analysis, when `--edge=both` was specified.

The issue was that the cutoff was being applied incorrectly using the distance to the gene TSS to the peak, whereas the distances to either edge should have been used (nb in this latter case peaks within the gene region have a distance of zero).