### PR TITLE
run_examples.sh: fix the setting of TEST_DIR for relative directories

### DIFF
--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -178,6 +178,8 @@ function assert_equal {
 TEST_DIR=$(dirname $0)
 if [ "$TEST_DIR" == "." ] ; then
     TEST_DIR=$(pwd)
+elif [ -z "$(echo $TEST_DIR | grep ^/)" ] ; then
+    TEST_DIR=$(pwd)/$TEST_DIR
 fi
 REF_DATA=$TEST_DIR/ref-data
 if [ ! -d test-output ] ; then


### PR DESCRIPTION
PR to fix a bug in the `run_examples.sh` testing script, when the script is run from a relative (rather than absolute) path.