### PR TITLE
WIP: update to work with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 language: python
 python:
   - "2.7"
+  - "3.7"
 
 install:
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
   - "3.7"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "3.6"
   - "3.7"
 

--- a/docs/additional_info.rst
+++ b/docs/additional_info.rst
@@ -10,6 +10,8 @@ Technical details
 Python:
 
  * 2.7
+ * 3.5
+ * 3.6
  * 3.7
 
 It requires the external ``xlsxwriter`` library in order to generate the

--- a/docs/additional_info.rst
+++ b/docs/additional_info.rst
@@ -6,8 +6,13 @@ Additional information
 Technical details
 -----------------
 
-``RnaChipIntegrator`` is known to work with Python 2.7, and
-requires the external ``xlsxwriter`` library in order to generate the
+``RnaChipIntegrator`` has been tested against the following versions of
+Python:
+
+ * 2.7
+ * 3.7
+
+It requires the external ``xlsxwriter`` library in order to generate the
 ``.xlsx`` Excel spreadsheets:
 
  * http://xlsxwriter.readthedocs.io/index.html

--- a/rnachipintegrator/Features.py
+++ b/rnachipintegrator/Features.py
@@ -128,7 +128,7 @@ class FeatureSet:
         fp.close()
         # Deal with postponed critical errors
         if critical_error:
-            raise Exception, "critical error(s) in '%s'" % features_file
+            raise Exception("Critical error(s) in '%s'" % features_file)
         # Store the source file
         self.source_file = features_file
         # Return a reference to this object

--- a/rnachipintegrator/Features.py
+++ b/rnachipintegrator/Features.py
@@ -12,8 +12,8 @@ Classes for handling feature data.
 """
 
 import logging
-from distances import closestDistanceToRegion
-from utils import make_errline
+from .distances import closestDistanceToRegion
+from .utils import make_errline
 
 class FeatureSet:
     """Class for storing a set of features

--- a/rnachipintegrator/Features.py
+++ b/rnachipintegrator/Features.py
@@ -59,74 +59,82 @@ class FeatureSet(object):
         line_index = 0
         critical_error = False
         # Read in data from file
-        fp = io.open(features_file,'rt')
-        for line in fp:
-            # Increment index
-            line_index += 1
-            # Skip lines starting with #
-            if line.startswith('#'):
-                logging.debug("Feature file: skipped line: %s" % line.strip())
-                continue
-            # Lines are tab-delimited and have at least 5 columns:
-            # ID  chr  start  end  strand
-            items = line.strip().split('\t')
-            if len(items) < 5:
-                logging.warning("Feature file: skipped line: %s" % line.strip())
-                logging.warning("Insufficient number of fields (%d)" % \
+        with io.open(features_file,'rt') as fp:
+            for line in fp:
+                # Increment index
+                line_index += 1
+                # Skip lines starting with #
+                if line.startswith('#'):
+                    logging.debug("Feature file: skipped line: %s" %
+                                  line.strip())
+                    continue
+                # Lines are tab-delimited and have at least 5 columns:
+                # ID  chr  start  end  strand
+                items = line.strip().split('\t')
+                if len(items) < 5:
+                    logging.warning("Feature file: skipped line: %s" %
+                                    line.strip())
+                    logging.warning("Insufficient number of fields (%d)" %
                                     len(items))
-                continue
-            # Check line is valid i.e. start and stop should be
-            # numbers, strand should be + or -
-            problem_fields = []
-            if not items[2].isdigit(): problem_fields.append(2)
-            if not items[3].isdigit(): problem_fields.append(3)
-            if not (items[4] == '+' or  items[4] == '-'): problem_fields.append(4)
-            if problem_fields:
-                # If this is the first line then assume it's a header and ignore
-                if line_index == 1:
-                    logging.warning("%s: first line ignored as header: %s" % 
-                                    (features_file,line.strip()))
-                else:
-                    # Indicate problem field(s)
-                    logging.error("%s: critical error line %d: bad values:" %
-                                  (features_file,line_index))
+                    continue
+                # Check line is valid i.e. start and stop should be
+                # numbers, strand should be + or -
+                problem_fields = []
+                if not items[2].isdigit():
+                    problem_fields.append(2)
+                if not items[3].isdigit():
+                    problem_fields.append(3)
+                if not (items[4] == '+' or  items[4] == '-'):
+                    problem_fields.append(4)
+                if problem_fields:
+                    # If this is the first line then assume it's a header
+                    # and ignore
+                    if line_index == 1:
+                        logging.warning("%s: first line ignored as header: "
+                                        "%s" % (features_file,line.strip()))
+                    else:
+                        # Indicate problem field(s)
+                        logging.error("%s: critical error line %d: bad "
+                                      "values:" % (features_file,line_index))
+                        logging.error("%s" % line.strip())
+                        logging.error("%s" % make_errline(line.strip(),
+                                                          problem_fields))
+                        # This is a critical error: update flag
+                        critical_error = True
+                    # Continue to next line
+                    continue
+                elif int(items[2]) >= int(items[3]):
+                    # Start position is same or higher than end
+                    logging.error("%s: critical error line %d: 'end' comes "
+                                  "before 'start':" % (features_file,
+                                                       line_index))
                     logging.error("%s" % line.strip())
-                    logging.error("%s" % make_errline(line.strip(),problem_fields))
-                    # This is a critical error: update flag
+                    logging.error("%s" % make_errline(line.strip(),(2,3)))
+                    # This is a critical error: update flag but continue
+                    # reading
                     critical_error = True
-                # Continue to next line
-                continue
-            elif int(items[2]) >= int(items[3]):
-                # Start position is same or higher than end
-                logging.error("%s: critical error line %d: 'end' comes before 'start':" %
-                              (features_file,line_index))
-                logging.error("%s" % line.strip())
-                logging.error("%s" % make_errline(line.strip(),(2,3)))
-                # This is a critical error: update flag but continue reading
-                critical_error = True
-                continue
-            # Store in a new Feature object
-            feature = Feature(items[0],
-                              items[1],
-                              items[2],
-                              items[3],
-                              items[4],
-                              source_file=features_file)
-            # Additional flag
-            if len(items) >= 6:
-                # Is column 6 a flag?
-                try:
-                    flag_value = int(items[5])
-                    if flag_value != 0 and flag_value != 1:
+                    continue
+                # Store in a new Feature object
+                feature = Feature(items[0],
+                                  items[1],
+                                  items[2],
+                                  items[3],
+                                  items[4],
+                                  source_file=features_file)
+                # Additional flag
+                if len(items) >= 6:
+                    # Is column 6 a flag?
+                    try:
+                        flag_value = int(items[5])
+                        if flag_value != 0 and flag_value != 1:
+                            flag_value = None
+                    except ValueError:
                         flag_value = None
-                except ValueError:
-                    flag_value = None
-                # Store value
-                feature.flag = flag_value
+                    # Store value
+                    feature.flag = flag_value
 
-            # Store data
-            self.features.append(feature)
-        fp.close()
+                # Store data
+                self.features.append(feature)
         # Deal with postponed critical errors
         if critical_error:
             raise Exception("Critical error(s) in '%s'" % features_file)

--- a/rnachipintegrator/Features.py
+++ b/rnachipintegrator/Features.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     Features.py: classes for handling feature data
-#     Copyright (C) University of Manchester 2011-15 Peter Briggs, Leo Zeef
+#     Copyright (C) University of Manchester 2011-2019 Peter Briggs, Leo Zeef
 #     & Ian Donaldson
 #
 """

--- a/rnachipintegrator/Features.py
+++ b/rnachipintegrator/Features.py
@@ -15,7 +15,7 @@ import logging
 from .distances import closestDistanceToRegion
 from .utils import make_errline
 
-class FeatureSet:
+class FeatureSet(object):
     """Class for storing a set of features
 
     RNA-seq features consists of genes/transcripts/isomers, which
@@ -321,7 +321,7 @@ class FeatureSet:
                 return True
         return False
 
-class Feature:
+class Feature(object):
     """Class for storing an 'feature' (gene/transcript/isomer)
 
     Access the data for the feature using the object's properties:

--- a/rnachipintegrator/Features.py
+++ b/rnachipintegrator/Features.py
@@ -12,6 +12,7 @@ Classes for handling feature data.
 """
 
 import logging
+import io
 from .distances import closestDistanceToRegion
 from .utils import make_errline
 
@@ -58,7 +59,7 @@ class FeatureSet(object):
         line_index = 0
         critical_error = False
         # Read in data from file
-        fp = open(features_file,'rU')
+        fp = io.open(features_file,'rt')
         for line in fp:
             # Increment index
             line_index += 1

--- a/rnachipintegrator/Peaks.py
+++ b/rnachipintegrator/Peaks.py
@@ -12,6 +12,7 @@ Classes for handling peak data
 """
 
 import logging
+import io
 from .utils import make_errline
 
 class PeakSet(object):
@@ -81,7 +82,7 @@ class PeakSet(object):
             ncols = max(ncols,id_column)
             id_column = id_column - 1
         # Read in from file
-        fp = open(peaks_file,'rU')
+        fp = io.open(peaks_file,'rt')
         for line in fp:
             # Skip lines that start with a # symbol
             if line.startswith('#'):

--- a/rnachipintegrator/Peaks.py
+++ b/rnachipintegrator/Peaks.py
@@ -118,7 +118,7 @@ class PeakSet:
                             items[end],
                             id=id_,
                             source_file=peaks_file)
-            except PeakRangeError,ex:
+            except PeakRangeError as ex:
                 logging.error("Peaks file: bad line: %s" % line.strip())
                 logging.error("                      %s" %
                               make_errline(line,(start,end)))

--- a/rnachipintegrator/Peaks.py
+++ b/rnachipintegrator/Peaks.py
@@ -14,7 +14,7 @@ Classes for handling peak data
 import logging
 from .utils import make_errline
 
-class PeakSet:
+class PeakSet(object):
     """Class for storing a set of peaks
 
     ChIP-seq data consists of ChIP peak information, each of which are
@@ -251,7 +251,7 @@ class PeakSet:
                 return True
         return False
 
-class Peak:
+class Peak(object):
     """Class for storing a peak
 
     Access the data from the line using the object's properties:

--- a/rnachipintegrator/Peaks.py
+++ b/rnachipintegrator/Peaks.py
@@ -82,51 +82,53 @@ class PeakSet(object):
             ncols = max(ncols,id_column)
             id_column = id_column - 1
         # Read in from file
-        fp = io.open(peaks_file,'rt')
-        for line in fp:
-            # Skip lines that start with a # symbol
-            if line.startswith('#'):
-                logging.debug("Peaks file: skipped line: %s" % line.strip())
-                continue
-            # Lines are tab-delimited
-            items = line.strip().split('\t')
-            if len(items) < ncols:
-                logging.warning("Peaks file: skipped line: %s" % line.strip())
-                logging.warning("Insufficient number of fields (%d): need at "
-                                "least %d" % (len(items),ncols))
-                continue
-            # Check that items in 'start' and 'end' columns are digits
-            if not items[start].isdigit() or not items[end].isdigit():
-                logging.warning("Peaks file: skipped line: %s" % line.strip())
-                # Indicate problem field(s)
-                bad_fields = []
-                for i in (start,end):
-                    if not items[i].isdigit():
-                        bad_fields.append(i)
-                logging.warning("                         %s" % \
-                                make_errline(line,bad_fields))
-                logging.warning("Expected integer at indicated positions")
-                continue
-            # Optional ID
-            try:
-                id_ = items[id_column]
-            except TypeError:
-                id_ = None
-            # Store in a new Peak object
-            try:
-                peak = Peak(items[chrom],
-                            items[start],
-                            items[end],
-                            id=id_,
-                            source_file=peaks_file)
-            except PeakRangeError as ex:
-                logging.error("Peaks file: bad line: %s" % line.strip())
-                logging.error("                      %s" %
-                              make_errline(line,(start,end)))
-                logging.error("%s" % ex)
-                raise ex
-            self.peaks.append(peak)
-        fp.close()
+        with io.open(peaks_file,'rt') as fp:
+            for line in fp:
+                # Skip lines that start with a # symbol
+                if line.startswith('#'):
+                    logging.debug("Peaks file: skipped line: %s" %
+                                  line.strip())
+                    continue
+                # Lines are tab-delimited
+                items = line.strip().split('\t')
+                if len(items) < ncols:
+                    logging.warning("Peaks file: skipped line: %s" %
+                                    line.strip())
+                    logging.warning("Insufficient number of fields (%d): "
+                                    "need at least %d" % (len(items),ncols))
+                    continue
+                # Check that items in 'start' and 'end' columns are digits
+                if not items[start].isdigit() or not items[end].isdigit():
+                    logging.warning("Peaks file: skipped line: %s" %
+                                    line.strip())
+                    # Indicate problem field(s)
+                    bad_fields = []
+                    for i in (start,end):
+                        if not items[i].isdigit():
+                            bad_fields.append(i)
+                    logging.warning("                         %s" % \
+                                    make_errline(line,bad_fields))
+                    logging.warning("Expected integer at indicated positions")
+                    continue
+                # Optional ID
+                try:
+                    id_ = items[id_column]
+                except TypeError:
+                    id_ = None
+                # Store in a new Peak object
+                try:
+                    peak = Peak(items[chrom],
+                                items[start],
+                                items[end],
+                                id=id_,
+                                source_file=peaks_file)
+                except PeakRangeError as ex:
+                    logging.error("Peaks file: bad line: %s" % line.strip())
+                    logging.error("                      %s" %
+                                  make_errline(line,(start,end)))
+                    logging.error("%s" % ex)
+                    raise ex
+                self.peaks.append(peak)
         # Store the source file
         self.source_file = peaks_file
         # Return a reference to this object

--- a/rnachipintegrator/Peaks.py
+++ b/rnachipintegrator/Peaks.py
@@ -12,7 +12,7 @@ Classes for handling peak data
 """
 
 import logging
-from utils import make_errline
+from .utils import make_errline
 
 class PeakSet:
     """Class for storing a set of peaks

--- a/rnachipintegrator/Peaks.py
+++ b/rnachipintegrator/Peaks.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     Peaks.py: classes for handling peak data
-#     Copyright (C) University of Manchester 2011-2018 Peter Briggs, Leo Zeef
+#     Copyright (C) University of Manchester 2011-2019 Peter Briggs, Leo Zeef
 #     & Ian Donaldson
 #
 """

--- a/rnachipintegrator/analysis.py
+++ b/rnachipintegrator/analysis.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     analysis.py: analyses of peaks vs features and vice versa
-#     Copyright (C) University of Manchester 2011-15 Peter Briggs, Leo Zeef
+#     Copyright (C) University of Manchester 2011-2019 Peter Briggs, Leo Zeef
 #     & Ian Donaldson
 #
 """

--- a/rnachipintegrator/analysis.py
+++ b/rnachipintegrator/analysis.py
@@ -15,9 +15,9 @@ Functions for analysing peaks against features, and vice versa:
 """
 import os
 import logging
-import distances
-from Features import FeatureSet
-from Peaks import PeakSet
+from . import distances
+from .Features import FeatureSet
+from .Peaks import PeakSet
 
 #######################################################################
 # Analysis functions

--- a/rnachipintegrator/cli.py
+++ b/rnachipintegrator/cli.py
@@ -29,9 +29,9 @@ import os
 import argparse
 from .Features import FeatureSet
 from .Peaks import PeakSet
-import analysis
-import output
-import xls_output
+from . import analysis
+from . import output
+from . import xls_output
 import logging
 from multiprocessing import Pool
 

--- a/rnachipintegrator/cli.py
+++ b/rnachipintegrator/cli.py
@@ -117,8 +117,10 @@ class CLI(object):
         self.parser = argparse.ArgumentParser(
             prog=self._prog,
             usage=usage,
-            version=self._version,
             description=description)
+        self.parser.add_argument('--version',
+                                 action='version',
+                                 version=self._version)
         self.option_groups = dict()
 
     def get_version(self):

--- a/rnachipintegrator/cli.py
+++ b/rnachipintegrator/cli.py
@@ -1192,7 +1192,7 @@ def main(args=None):
                               else "No"))
         # Add features to peaks
         if peak_centric:
-            names = sorted(peak_centric_outputs.keys())
+            names = sorted(list(peak_centric_outputs))
             xlsx.write_peak_centric(peak_fields)
             if options.summary:
                 xlsx.append_to_notes("\n'Peak-centric (summary)' lists the "
@@ -1212,7 +1212,7 @@ def main(args=None):
                                           peak_centric_summary[name])
         # Add peaks to features
         if gene_centric:
-            names = sorted(gene_centric_outputs.keys())
+            names = sorted(list(gene_centric_outputs))
             xlsx.write_feature_centric(gene_fields)
             if options.summary:
                 xlsx.append_to_notes("\n'%s-centric (summary)' lists the "

--- a/rnachipintegrator/distances.py
+++ b/rnachipintegrator/distances.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     distances.py: functions for determining distances and overlaps
-#     Copyright (C) University of Manchester 2011-15 Peter Briggs, Leo Zeef
+#     Copyright (C) University of Manchester 2011-2019 Peter Briggs, Leo Zeef
 #     & Ian Donaldson
 #
 """

--- a/rnachipintegrator/output.py
+++ b/rnachipintegrator/output.py
@@ -58,7 +58,7 @@ FIELDS = {
 # Classes
 #######################################################################
 
-class AnalysisReporter:
+class AnalysisReporter(object):
     """
     Class to handle reporting of analysis results
 

--- a/rnachipintegrator/output.py
+++ b/rnachipintegrator/output.py
@@ -195,7 +195,8 @@ class AnalysisReporter:
             results = results[:]
         nresults = len(results)
         # Pad with null results
-        if self._mode == SINGLE_LINE or self._pad:
+        if self._max_hits is not None and (self._mode == SINGLE_LINE or
+                                           self._pad):
             while len(results) < self._max_hits:
                 if is_features:
                     results.addFeature(None)

--- a/rnachipintegrator/output.py
+++ b/rnachipintegrator/output.py
@@ -10,8 +10,8 @@ output.py
 Functions for outputing analysis results
 
 """
-import distances
-from Peaks import Peak
+from . import distances
+from .Peaks import Peak
 import tempfile
 
 #######################################################################

--- a/rnachipintegrator/output.py
+++ b/rnachipintegrator/output.py
@@ -12,6 +12,7 @@ Functions for outputing analysis results
 """
 from . import distances
 from .Peaks import Peak
+import io
 import tempfile
 
 #######################################################################
@@ -492,13 +493,13 @@ class AnalysisReportWriter(AnalysisReporter):
         self.outfile = outfile
         if self.outfile is not None:
             # Open temporary file to handle output
-            self._fp = tempfile.TemporaryFile()
+            self._fp = tempfile.TemporaryFile(mode='w+t')
         else:
             self._fp = None
         self.summary = summary
         if self.summary is not None:
             # Open temporary file to handle summary
-            self._summary = tempfile.TemporaryFile()
+            self._summary = tempfile.TemporaryFile(mode='w+t')
         else:
             self._summary = None
         self._append = bool(append)
@@ -550,18 +551,18 @@ class AnalysisReportWriter(AnalysisReporter):
         """
         # Set the mode
         if self._append:
-            mode = 'a'
+            mode = 'at'
         else:
-            mode = 'w'
+            mode = 'wt'
         # Full output file
         if self.outfile:
             # Rewind to the start of the temp file
             self._fp.seek(0)
             # Write the final output file
-            with open(self.outfile,mode) as fp:
+            with io.open(self.outfile,mode) as fp:
                 if not self._append:
                     # Write the header
-                    fp.write("#%s\n" % self.make_header())
+                    fp.write(u"#%s\n" % self.make_header())
                 # Write the content
                 nitems = len(self.make_header().split('\t'))
                 for line in self._fp:
@@ -571,7 +572,7 @@ class AnalysisReportWriter(AnalysisReporter):
                         while len(fields) < nitems:
                             fields.append(self._placeholder)
                         line = '\t'.join(fields) + '\n'
-                    fp.write(line)
+                    fp.write(u"%s" % line)
             # Dispose of the temp file
             self._fp.close()
         # Summary output file
@@ -579,13 +580,13 @@ class AnalysisReportWriter(AnalysisReporter):
             # Rewind to the start of the temp file
             self._summary.seek(0)
             # Write the final summary file
-            with open(self.summary,mode) as fp:
+            with io.open(self.summary,mode) as fp:
                 if not self._append:
                     # Write the header
-                    fp.write("#%s\n" % self.make_header())
+                    fp.write(u"#%s\n" % self.make_header())
                 # Write the content
                 for line in self._summary:
-                    fp.write(line)
+                    fp.write(u"%s" % line)
             # Dispose of the temp file
             self._summary.close()
 

--- a/rnachipintegrator/output.py
+++ b/rnachipintegrator/output.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     output.py: functions for outputting analysis results
-#     Copyright (C) University of Manchester 2015-2018 Peter Briggs,
+#     Copyright (C) University of Manchester 2015-2019 Peter Briggs,
 #     Leo Zeef & Ian Donaldson
 #
 """

--- a/rnachipintegrator/xls_output.py
+++ b/rnachipintegrator/xls_output.py
@@ -37,7 +37,7 @@ NOTES['feature_centric'] = """
 <style font=bold bgcolor=gray>'%s-centric': nearest peaks to each %s</style>
 Column\tDescription"""
 
-class XLSX:
+class XLSX(object):
     """
     Class to assemble XLSX output file
 

--- a/rnachipintegrator/xls_output.py
+++ b/rnachipintegrator/xls_output.py
@@ -13,8 +13,8 @@ Functions for outputting analysis results to XLSX spreadsheet
 import datetime
 import xlsxwriter
 import re
-import output
-import utils
+from . import output
+from . import utils
 
 # Regular expressions for styling tags
 RE_STYLE = re.compile(r"^<style +([^>]*)>(.*)</style>$")

--- a/rnachipintegrator/xls_output.py
+++ b/rnachipintegrator/xls_output.py
@@ -12,6 +12,7 @@ Functions for outputting analysis results to XLSX spreadsheet
 """
 import datetime
 import xlsxwriter
+import io
 import re
 from . import output
 from . import utils
@@ -252,7 +253,7 @@ class XLSX(object):
         """
         ws = self.add_sheet(title)
         # Get header line
-        with open(tsv_file,'r') as fp:
+        with io.open(tsv_file,'rt') as fp:
             i = self._rows[title]
             for line in fp:
                 j = 0

--- a/rnachipintegrator/xls_output.py
+++ b/rnachipintegrator/xls_output.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     xls_output.py: functions for writing analysis results to Excel files
-#     Copyright (C) University of Manchester 2015-16 Peter Briggs, Leo Zeef
+#     Copyright (C) University of Manchester 2015-2019 Peter Briggs, Leo Zeef
 #     & Ian Donaldson
 #
 """

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         "Programming Language :: Python :: 3",
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
     install_requires = ['xlsxwriter >= 0.8.4',],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 Setup script to install RnaChipIntegrator: analyses of peak data with
 genomic feature data
 
-Copyright (C) University of Manchester 2011-16 Peter Briggs, Ian Donaldson, Leo Zeef
+Copyright (C) University of Manchester 2011-19 Peter Briggs, Ian Donaldson, Leo Zeef
 
 """
 
@@ -49,6 +49,8 @@ setup(
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
+        "Programming Language :: Python :: 3",
+        'Programming Language :: Python :: 3.7',
     ],
     install_requires = ['xlsxwriter >= 0.8.4',],
     test_suite = 'nose.collector',

--- a/test/common.py
+++ b/test/common.py
@@ -4,6 +4,8 @@
 #
 #########################################################################
 #
+import io
+#
 # Transcripts-ex1.txt
 transcripts_ex1 = \
 """CG9130-RB	chr3L	1252012	1255989	+	1
@@ -246,9 +248,9 @@ from nose.tools import nottest
 @nottest
 def create_test_file(name,data):
     # Writes data to a file to be used in testing
-    fp = open(name,'w')
+    fp = io.open(name,'wt')
     for line in data.split('\n'):
-        fp.write(line+'\n')
+        fp.write(u"%s\n" % line)
     fp.close()
 
 @nottest

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -294,7 +294,8 @@ AK082264_C230030N03Rik	chr1	34735043	34781084	+	1
 BC006931_AI597479	chr1	43153807	43172843	+	1
 """
         feature_file = os.path.join(self.wd,"features.txt")
-        io.open(feature_file,'wt').write(feature_data)
+        with io.open(feature_file,'wt') as fp:
+            fp.write(feature_data)
         features = read_feature_file(feature_file)
         self.assertEqual(len(features),4)
 
@@ -307,7 +308,8 @@ AK082264_C230030N03Rik	chr1	34735043	34781084	+	1
 BC006931_AI597479	chr1	43153807	43172843	+	1
 """
         feature_file = os.path.join(self.wd,"features.txt")
-        io.open(feature_file,'wt').write(feature_data)
+        with io.open(feature_file,'wt') as fp:
+            fp.write(feature_data)
         features = read_feature_file(feature_file)
         self.assertEqual(len(features),4)
 
@@ -332,7 +334,8 @@ chr1	24609562	24609623
 chr1	24609562	24609623
 """
         peak_file = os.path.join(self.wd,"peaks.txt")
-        io.open(peak_file,'wt').write(peak_data)
+        with io.open(peak_file,'wt') as fp:
+            fp.write(peak_data)
         peaks = read_peak_file(peak_file)
         self.assertEqual(len(peaks),8)
 
@@ -349,7 +352,8 @@ chr1	24609562	24609623
 chr1	24609562	24609623
 """
         peak_file = os.path.join(self.wd,"peaks.txt")
-        io.open(peak_file,'wt').write(peak_data)
+        with io.open(peak_file,'wt') as fp:
+            fp.write(peak_data)
         peaks = read_peak_file(peak_file)
         self.assertEqual(len(peaks),8)
 
@@ -365,7 +369,8 @@ u"""9619046	9619167	chr1
 24609562	24609623	chr1
 """
         peak_file = os.path.join(self.wd,"peaks.txt")
-        io.open(peak_file,'wt').write(peak_data)
+        with io.open(peak_file,'wt') as fp:
+            fp.write(peak_data)
         peaks = read_peak_file(peak_file,peak_cols=(3,1,2))
         self.assertEqual(len(peaks),8)
 
@@ -381,7 +386,8 @@ chr1	24609562	24609623	P007
 chr1	24609562	24609623	P008
 """
         peak_file = os.path.join(self.wd,"peaks.txt")
-        io.open(peak_file,'wt').write(peak_data)
+        with io.open(peak_file,'wt') as fp:
+            fp.write(peak_data)
         peaks = read_peak_file(peak_file,peak_id_col=4)
         self.assertEqual(len(peaks),8)
         for peak in peaks:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,6 +6,7 @@ import unittest
 import tempfile
 import shutil
 import os
+import io
 from rnachipintegrator.cli import CLI
 from rnachipintegrator.cli import OutputFiles
 from rnachipintegrator.cli import AnalysisParams
@@ -286,27 +287,27 @@ class TestReadFeatureFile(unittest.TestCase):
 
     def test_read_feature_file(self):
         feature_data = \
-"""
+u"""
 AK030377_A330023F24Rik	chr1	196781953	196826186	-	1
 AK080193_A530079E22Rik	chr1	89401837	89403491	-	1
 AK082264_C230030N03Rik	chr1	34735043	34781084	+	1
 BC006931_AI597479	chr1	43153807	43172843	+	1
 """
         feature_file = os.path.join(self.wd,"features.txt")
-        open(feature_file,'w').write(feature_data)
+        io.open(feature_file,'wt').write(feature_data)
         features = read_feature_file(feature_file)
         self.assertEqual(len(features),4)
 
     def test_read_feature_file_with_header(self):
         feature_data = \
-"""RefSeq_Gene Symbol	chr1	start	stop	strand	diff_exp
+u"""RefSeq_Gene Symbol	chr1	start	stop	strand	diff_exp
 AK030377_A330023F24Rik	chr1	196781953	196826186	-	1
 AK080193_A530079E22Rik	chr1	89401837	89403491	-	1
 AK082264_C230030N03Rik	chr1	34735043	34781084	+	1
 BC006931_AI597479	chr1	43153807	43172843	+	1
 """
         feature_file = os.path.join(self.wd,"features.txt")
-        open(feature_file,'w').write(feature_data)
+        io.open(feature_file,'wt').write(feature_data)
         features = read_feature_file(feature_file)
         self.assertEqual(len(features),4)
 
@@ -321,7 +322,7 @@ class TestReadPeakFile(unittest.TestCase):
 
     def test_read_peak_file(self):
         peak_data = \
-"""chr1	9619046	9619167
+u"""chr1	9619046	9619167
 chr1	9619175	9619382
 chr1	10617233	10617437
 chr1	13829227	13829564
@@ -331,13 +332,13 @@ chr1	24609562	24609623
 chr1	24609562	24609623
 """
         peak_file = os.path.join(self.wd,"peaks.txt")
-        open(peak_file,'w').write(peak_data)
+        io.open(peak_file,'wt').write(peak_data)
         peaks = read_peak_file(peak_file)
         self.assertEqual(len(peaks),8)
 
     def test_read_peak_file_with_header(self):
         peak_data = \
-"""peak	s	e
+u"""peak	s	e
 chr1	9619046	9619167
 chr1	9619175	9619382
 chr1	10617233	10617437
@@ -348,13 +349,13 @@ chr1	24609562	24609623
 chr1	24609562	24609623
 """
         peak_file = os.path.join(self.wd,"peaks.txt")
-        open(peak_file,'w').write(peak_data)
+        io.open(peak_file,'wt').write(peak_data)
         peaks = read_peak_file(peak_file)
         self.assertEqual(len(peaks),8)
 
     def test_read_peak_file_cols(self):
         peak_data = \
-"""9619046	9619167	chr1
+u"""9619046	9619167	chr1
 9619175	9619382	chr1
 10617233	10617437	chr1
 13829227	13829564	chr1
@@ -364,13 +365,13 @@ chr1	24609562	24609623
 24609562	24609623	chr1
 """
         peak_file = os.path.join(self.wd,"peaks.txt")
-        open(peak_file,'w').write(peak_data)
+        io.open(peak_file,'wt').write(peak_data)
         peaks = read_peak_file(peak_file,peak_cols=(3,1,2))
         self.assertEqual(len(peaks),8)
 
     def test_read_peak_file_ids(self):
         peak_data = \
-"""chr1	9619046	9619167	P001
+u"""chr1	9619046	9619167	P001
 chr1	9619175	9619382	P002
 chr1	10617233	10617437	P003
 chr1	13829227	13829564	P004
@@ -380,7 +381,7 @@ chr1	24609562	24609623	P007
 chr1	24609562	24609623	P008
 """
         peak_file = os.path.join(self.wd,"peaks.txt")
-        open(peak_file,'w').write(peak_data)
+        io.open(peak_file,'wt').write(peak_data)
         peaks = read_peak_file(peak_file,peak_id_col=4)
         self.assertEqual(len(peaks),8)
         for peak in peaks:

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -606,7 +606,8 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "chr2L\t66811\t66812\t1 of 3\tCG31973\t7568\t7568\n" \
             "chr2L\t66811\t66812\t2 of 3\tCG2674-RE\t40091\t40091\n" \
             "chr2L\t66811\t66812\t3 of 3\tCG2674-RC\t41114\t41114\n"
-        actual_output = io.open(outfile,'rt').read()
+        with io.open(outfile,'rt') as fp:
+            actual_output = fp.read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -639,7 +640,8 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "chr2L\t66811\t66812\t1 of 3\t100000\tCG31973\t7568\t7568\n" \
             "chr2L\t66811\t66812\t2 of 3\t100000\tCG2674-RE\t40091\t40091\n" \
             "chr2L\t66811\t66812\t3 of 3\t100000\tCG2674-RC\t41114\t41114\n"
-        actual_output = io.open(outfile,'rt').read()
+        with io.open(outfile,'rt') as fp:
+            actual_output = fp.read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -669,7 +671,8 @@ class TestAnalysisReportWriter(unittest.TestCase):
         expected_output = \
             "#peak.chr\tpeak.start\tpeak.end\torder\tfeature.id\tdist_closest\tdist_TSS\n" \
             "chr2L\t66811\t66812\t1 of 3\tCG31973\t7568\t7568\n"
-        actual_output = io.open(summary,'rt').read()
+        with io.open(summary,'rt') as fp:
+            actual_output = fp.read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -716,7 +719,8 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "chr2L\t66811\t66812\t1 of 2\tCG31973\t7568\t7568\n" \
             "chr2L\t66811\t66812\t2 of 2\tCG2674-RE\t40091\t40091\n" \
             "chr2L\t66811\t66812\t1 of 1\tCG2674-RC\t41114\t41114\n"
-        actual_output = io.open(outfile,'rt').read()
+        with io.open(outfile,'rt') as fp:
+            actual_output = fp.read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -748,7 +752,8 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "CG31973\t1 of 3\tchr2L\t66711\t66911\t7468\t7468\n" \
             "CG31973\t2 of 3\tchr2L\t249077\t249277\t189834\t189834\n" \
             "CG31973\t3 of 3\tchr2L\t605850\t606050\t546607\t546607\n"
-        actual_output = io.open(outfile,'rt').read()
+        with io.open(outfile,'rt') as fp:
+            actual_output = fp.read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -781,7 +786,8 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "CG31973\t1 of 3\tchr2L\t66711\t66911\t100000\t7468\t7468\n" \
             "CG31973\t2 of 3\tchr2L\t249077\t249277\t100000\t189834\t189834\n" \
             "CG31973\t3 of 3\tchr2L\t605850\t606050\t100000\t546607\t546607\n"
-        actual_output = io.open(outfile,'rt').read()
+        with io.open(outfile,'rt') as fp:
+            actual_output = fp.read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -811,7 +817,8 @@ class TestAnalysisReportWriter(unittest.TestCase):
         expected_output = \
             "#feature.id\torder\tpeak.chr\tpeak.start\tpeak.end\tdist_closest\tdist_TSS\n" \
             "CG31973\t1 of 3\tchr2L\t66711\t66911\t7468\t7468\n"
-        actual_output = io.open(summary,'rt').read()
+        with io.open(summary,'rt') as fp:
+            actual_output = fp.read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -3,6 +3,7 @@
 #     Copyright (C) University of Manchester 2011-2018 Peter Briggs
 
 import unittest
+import io
 try:
     # Python2
     from itertools import izip_longest as zip_longest
@@ -605,7 +606,7 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "chr2L\t66811\t66812\t1 of 3\tCG31973\t7568\t7568\n" \
             "chr2L\t66811\t66812\t2 of 3\tCG2674-RE\t40091\t40091\n" \
             "chr2L\t66811\t66812\t3 of 3\tCG2674-RC\t41114\t41114\n"
-        actual_output = open(outfile,'r').read()
+        actual_output = io.open(outfile,'rt').read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -638,7 +639,7 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "chr2L\t66811\t66812\t1 of 3\t100000\tCG31973\t7568\t7568\n" \
             "chr2L\t66811\t66812\t2 of 3\t100000\tCG2674-RE\t40091\t40091\n" \
             "chr2L\t66811\t66812\t3 of 3\t100000\tCG2674-RC\t41114\t41114\n"
-        actual_output = open(outfile,'r').read()
+        actual_output = io.open(outfile,'rt').read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -668,7 +669,7 @@ class TestAnalysisReportWriter(unittest.TestCase):
         expected_output = \
             "#peak.chr\tpeak.start\tpeak.end\torder\tfeature.id\tdist_closest\tdist_TSS\n" \
             "chr2L\t66811\t66812\t1 of 3\tCG31973\t7568\t7568\n"
-        actual_output = open(summary,'r').read()
+        actual_output = io.open(summary,'rt').read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -715,7 +716,7 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "chr2L\t66811\t66812\t1 of 2\tCG31973\t7568\t7568\n" \
             "chr2L\t66811\t66812\t2 of 2\tCG2674-RE\t40091\t40091\n" \
             "chr2L\t66811\t66812\t1 of 1\tCG2674-RC\t41114\t41114\n"
-        actual_output = open(outfile,'r').read()
+        actual_output = io.open(outfile,'rt').read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -747,7 +748,7 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "CG31973\t1 of 3\tchr2L\t66711\t66911\t7468\t7468\n" \
             "CG31973\t2 of 3\tchr2L\t249077\t249277\t189834\t189834\n" \
             "CG31973\t3 of 3\tchr2L\t605850\t606050\t546607\t546607\n"
-        actual_output = open(outfile,'r').read()
+        actual_output = io.open(outfile,'rt').read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -780,7 +781,7 @@ class TestAnalysisReportWriter(unittest.TestCase):
             "CG31973\t1 of 3\tchr2L\t66711\t66911\t100000\t7468\t7468\n" \
             "CG31973\t2 of 3\tchr2L\t249077\t249277\t100000\t189834\t189834\n" \
             "CG31973\t3 of 3\tchr2L\t605850\t606050\t100000\t546607\t546607\n"
-        actual_output = open(outfile,'r').read()
+        actual_output = io.open(outfile,'rt').read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 
@@ -810,7 +811,7 @@ class TestAnalysisReportWriter(unittest.TestCase):
         expected_output = \
             "#feature.id\torder\tpeak.chr\tpeak.start\tpeak.end\tdist_closest\tdist_TSS\n" \
             "CG31973\t1 of 3\tchr2L\t66711\t66911\t7468\t7468\n"
-        actual_output = open(summary,'r').read()
+        actual_output = io.open(summary,'rt').read()
         # Check that output matches
         self.assertEqual(expected_output,actual_output)
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -3,7 +3,12 @@
 #     Copyright (C) University of Manchester 2011-2018 Peter Briggs
 
 import unittest
-from itertools import izip_longest
+try:
+    # Python2
+    from itertools import izip_longest as zip_longest
+except ImportError:
+    # Python3
+    from itertools import zip_longest
 import rnachipintegrator.output as output
 from rnachipintegrator.output import AnalysisReporter,AnalysisReportWriter
 from rnachipintegrator.output import describe_fields
@@ -150,7 +155,7 @@ class TestAnalysisReporterNearestFeatures(unittest.TestCase):
         ap = AnalysisReporter(output.SINGLE_LINE,
                               fields=self.single_line_fields)
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_features(self.peak,
                                            self.features),
                 expected):
@@ -168,7 +173,7 @@ class TestAnalysisReporterNearestFeatures(unittest.TestCase):
                               fields=self.single_line_fields,
                               max_hits=2)
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_features(self.peak,
                                            self.features),
                 expected):
@@ -190,7 +195,7 @@ class TestAnalysisReporterNearestFeatures(unittest.TestCase):
                               pad=True,
                               null_placeholder='.')
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_features(self.peak,
                                            self.features),
                 expected):
@@ -208,7 +213,7 @@ class TestAnalysisReporterNearestFeatures(unittest.TestCase):
                               fields=self.single_line_fields_extra_data,
                               max_hits=2)
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_features(self.peak,
                                            self.features,
                                            cutoff=100000),
@@ -226,7 +231,7 @@ class TestAnalysisReporterNearestFeatures(unittest.TestCase):
         ap = AnalysisReporter(output.MULTI_LINE,
                               fields=self.multi_line_fields)
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_features(self.peak,
                                            self.features),
                 expected):
@@ -243,7 +248,7 @@ class TestAnalysisReporterNearestFeatures(unittest.TestCase):
                               fields=self.multi_line_fields,
                               max_hits=2)
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_features(self.peak,
                                            self.features),
                 expected):
@@ -264,7 +269,7 @@ class TestAnalysisReporterNearestFeatures(unittest.TestCase):
                               pad=True,
                               null_placeholder='.')
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_features(self.peak,
                                            self.features),
                 expected):
@@ -309,7 +314,7 @@ class TestAnalysisReporterNearestPeaks(unittest.TestCase):
         ap = AnalysisReporter(output.SINGLE_LINE,
                               fields=self.single_line_fields)
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_peaks(self.feature,
                                         self.peaks),
                 expected):
@@ -328,7 +333,7 @@ class TestAnalysisReporterNearestPeaks(unittest.TestCase):
                               max_hits=2,
                               null_placeholder='.')
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_peaks(self.feature,
                                         self.peaks),
                 expected):
@@ -349,7 +354,7 @@ class TestAnalysisReporterNearestPeaks(unittest.TestCase):
                               max_hits=4,
                               pad=True)
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_peaks(self.feature,
                                         self.peaks),
                 expected):
@@ -368,7 +373,7 @@ class TestAnalysisReporterNearestPeaks(unittest.TestCase):
                               max_hits=2,
                               null_placeholder='.')
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_peaks(self.feature,
                                         self.peaks,
                                         cutoff=100000),
@@ -386,7 +391,7 @@ class TestAnalysisReporterNearestPeaks(unittest.TestCase):
         ap = AnalysisReporter(output.MULTI_LINE,
                               fields=self.multi_line_fields)
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_peaks(self.feature,
                                         self.peaks),
                 expected):
@@ -403,7 +408,7 @@ class TestAnalysisReporterNearestPeaks(unittest.TestCase):
                               fields=self.multi_line_fields,
                               max_hits=2)
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_peaks(self.feature,
                                         self.peaks),
                 expected):
@@ -424,7 +429,7 @@ class TestAnalysisReporterNearestPeaks(unittest.TestCase):
                               pad=True,
                               null_placeholder='.')
         # Check that output matches
-        for line,expected_line in izip_longest(
+        for line,expected_line in zip_longest(
                 ap.report_nearest_peaks(self.feature,
                                         self.peaks),
                 expected):


### PR DESCRIPTION
PR to address issue #62 and update `RnaChipIntegrator` to work with Python 3 (preferably while still retaining backwards compatibility with Python 2.7).

The current version of Python is 3.7, and it looks like 3.6 and 3.5 are still supported, so these are the three versions we'll target:

* [x] Python 3.7
* [x] Python 3.6
* [x] Python 3.5