### PR TITLE
Fix the PyPI badge in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ RnaChipIntegrator: analysis of genes with peak data
 .. image:: https://readthedocs.org/projects/rnachipintegrator/badge/?version=latest
    :target: https://rnachipintegrator.readthedocs.io
 
-.. image:: https://badge.fury.io/py/rnachipintegrator.svg
+.. image:: https://badge.fury.io/py/RnaChipIntegrator.svg
    :target: https://pypi.python.org/pypi/rnachipintegrator/
 
 .. image:: https://travis-ci.org/fls-bioinformatics-core/RnaChipIntegrator.png?branch=master


### PR DESCRIPTION
PR to update the URL for the PyPI "badge" in the `README`, so that it displays the current version correctly when viewed on GitHub.