### PR TITLE
Rename utility functions to fix running tests with 'nose'

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -244,14 +244,14 @@ CG18024-RA	chr2L	8825625	8829671	+	1	3	chr2L	8825470	155	chr2L	8832523	-6898	chr
 
 import os
 
-def create_test_file(name,data):
+def create_file(name,data):
     # Writes data to a file to be used in testing
     fp = io.open(name,'wt')
     for line in data.split('\n'):
         fp.write(u"%s\n" % line)
     fp.close()
 
-def delete_test_file(name):
+def delete_file(name):
     # Deletes named test file
     if os.path.exists(name):
         os.remove(name)

--- a/test/test_Features.py
+++ b/test/test_Features.py
@@ -125,14 +125,14 @@ class TestFeatureSet(unittest.TestCase):
 
     def setUp(self):
         # Create input files for tests
-        create_test_file('Transcripts-ex1.txt',transcripts_ex1)
-        create_test_file('Transcripts-ex2.txt',transcripts_ex2)
-        create_test_file('Transcripts-ex2a.txt',transcripts_ex2a)
+        create_file('Transcripts-ex1.txt',transcripts_ex1)
+        create_file('Transcripts-ex2.txt',transcripts_ex2)
+        create_file('Transcripts-ex2a.txt',transcripts_ex2a)
 
     def tearDown(self):
         # Remove input files
-        delete_test_file('Transcripts-ex1.txt')
-        delete_test_file('Transcripts-ex2.txt')
+        delete_file('Transcripts-ex1.txt')
+        delete_file('Transcripts-ex2.txt')
 
     def test_populate_from_list_of_features(self):
         features = FeatureSet(

--- a/test/test_Peaks.py
+++ b/test/test_Peaks.py
@@ -14,21 +14,21 @@ class TestPeakSet(unittest.TestCase):
 
     def setUp(self):
         # Create input files for tests
-        create_test_file('ChIP_peaks-ex1.txt',chip_peaks_ex1)
-        create_test_file('ChIP_peaks-ex2.txt',chip_peaks_ex2)
-        create_test_file('ChIP_peaks-ex5.txt',chip_peaks_ex5)
-        create_test_file('ChIP_peaks-ex6.txt',chip_peaks_ex6)
-        create_test_file('ChIP_peaks-ex7.txt',chip_peaks_ex7)
-        create_test_file('ChIP_peaks_multi_columns-ex1.txt',
-                         chip_peaks_multi_columns_ex1)
+        create_file('ChIP_peaks-ex1.txt',chip_peaks_ex1)
+        create_file('ChIP_peaks-ex2.txt',chip_peaks_ex2)
+        create_file('ChIP_peaks-ex5.txt',chip_peaks_ex5)
+        create_file('ChIP_peaks-ex6.txt',chip_peaks_ex6)
+        create_file('ChIP_peaks-ex7.txt',chip_peaks_ex7)
+        create_file('ChIP_peaks_multi_columns-ex1.txt',
+                    chip_peaks_multi_columns_ex1)
 
     def tearDown(self):
         # Remove input files
-        delete_test_file('ChIP_peaks-ex1.txt')
-        delete_test_file('ChIP_peaks-ex2.txt')
-        delete_test_file('ChIP_peaks-ex5.txt')
-        delete_test_file('ChIP_peaks-ex6.txt')
-        delete_test_file('ChIP_peaks-ex7.txt')
+        delete_file('ChIP_peaks-ex1.txt')
+        delete_file('ChIP_peaks-ex2.txt')
+        delete_file('ChIP_peaks-ex5.txt')
+        delete_file('ChIP_peaks-ex6.txt')
+        delete_file('ChIP_peaks-ex7.txt')
 
     def test_reading_in_ChIPseq_data(self):
         peaks = PeakSet('ChIP_peaks-ex1.txt')
@@ -230,13 +230,13 @@ class TestPeak(unittest.TestCase):
 class TestFeatureSetWithChIPSeqData(unittest.TestCase):
     def setUp(self):
         # Create input files for tests
-        create_test_file('Transcripts-ex1.txt',transcripts_ex1)
-        create_test_file('ChIP_peaks-ex1.txt',chip_peaks_ex1)
+        create_file('Transcripts-ex1.txt',transcripts_ex1)
+        create_file('ChIP_peaks-ex1.txt',chip_peaks_ex1)
 
     def tearDown(self):
         # Remove input files
-        delete_test_file('Transcripts-ex1.txt')
-        delete_test_file('ChIP_peaks-ex1.txt')
+        delete_file('Transcripts-ex1.txt')
+        delete_file('ChIP_peaks-ex1.txt')
 
     def test_closest_transcript_to_peak(self):
         features = FeatureSet('Transcripts-ex1.txt')

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1,6 +1,6 @@
 #
 #     test_analysis.py: unit tests for analysis module
-#     Copyright (C) University of Manchester 2011-5 Peter Briggs
+#     Copyright (C) University of Manchester 2011-5,2024 Peter Briggs
 
 import unittest
 from rnachipintegrator.Features import FeatureSet,Feature
@@ -41,15 +41,15 @@ class TestFindNearestFeaturesForSummits(unittest.TestCase):
 
     def setUp(self):
         # Set up data for tests
-        create_test_file('features.txt',feature_data)
-        create_test_file('summits.txt',summit_data)
+        create_file('features.txt',feature_data)
+        create_file('summits.txt',summit_data)
         self.features = FeatureSet('features.txt')
         self.summits = PeakSet('summits.txt')
 
     def tearDown(self):
         # Remove input files
-        delete_test_file('features.txt')
-        delete_test_file('summits.txt')
+        delete_file('features.txt')
+        delete_file('summits.txt')
 
     def test_find_nearest_features_doesnt_change_input_features(self):
         # Check that the input FeatureSet is not altered by the analysis
@@ -387,15 +387,15 @@ class TestFindNearestFeaturesForRegions(unittest.TestCase):
 
     def setUp(self):
         # Set up data for tests
-        create_test_file('features.txt',feature_data)
-        create_test_file('peaks.txt',peak_data)
+        create_file('features.txt',feature_data)
+        create_file('peaks.txt',peak_data)
         self.features = FeatureSet('features.txt')
         self.peaks = PeakSet('peaks.txt')
 
     def tearDown(self):
         # Remove input files
-        delete_test_file('features.txt')
-        delete_test_file('peaks.txt')
+        delete_file('features.txt')
+        delete_file('peaks.txt')
 
     def test_find_nearest_features_doesnt_change_input_features(self):
         # Check that the input FeatureSet is not altered by the analysis
@@ -744,15 +744,15 @@ class TestFindNearestPeaksForSummits(unittest.TestCase):
 
     def setUp(self):
         # Set up data for tests
-        create_test_file('features.txt',feature_data)
-        create_test_file('summits.txt',summit_data)
+        create_file('features.txt',feature_data)
+        create_file('summits.txt',summit_data)
         self.features = FeatureSet('features.txt')
         self.summits = PeakSet('summits.txt')
 
     def tearDown(self):
         # Remove input files
-        delete_test_file('features.txt')
-        delete_test_file('summits.txt')
+        delete_file('features.txt')
+        delete_file('summits.txt')
 
     def test_find_nearest_peaks_summits(self):
         # Run the analysis
@@ -1153,15 +1153,15 @@ class TestFindNearestPeaksForRegions(unittest.TestCase):
 
     def setUp(self):
         # Set up data for tests
-        create_test_file('features.txt',feature_data)
-        create_test_file('peaks.txt',peak_data)
+        create_file('features.txt',feature_data)
+        create_file('peaks.txt',peak_data)
         self.features = FeatureSet('features.txt')
         self.peaks = PeakSet('peaks.txt')
 
     def tearDown(self):
         # Remove input files
-        delete_test_file('features.txt')
-        delete_test_file('peaks.txt')
+        delete_file('features.txt')
+        delete_file('peaks.txt')
 
     def test_find_nearest_peaks_regions(self):
         # Run the analysis


### PR DESCRIPTION
Rename the `create_test_file` and `delete_test_file` functions in `test/common.py` to `create_file` and `delete_file` (i.e. remove the `_test` component), to fix errors when running unit tests with `nose`. Without the changes, `nosetests` treats these helper function as test cases (which then fail).