### PR TITLE
Drop support for Python 2.7 and update CI testing for EOL Python 3.6

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,7 +8,9 @@ on: [ push, pull_request ]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    # Switched from ubuntu-latest to ubuntu-20.04 as former
+    # doesn't support Python 3.6
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/docs/additional_info.rst
+++ b/docs/additional_info.rst
@@ -9,11 +9,11 @@ Technical details
 ``RnaChipIntegrator`` has been tested against the following versions of
 Python:
 
- * 2.7
  * 3.5
  * 3.6
  * 3.7
  * 3.8
+ * 3.9
 
 It requires the external ``xlsxwriter`` library in order to generate the
 ``.xlsx`` Excel spreadsheets:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@
 Setup script to install RnaChipIntegrator: analyses of peak data with
 genomic feature data
 
-Copyright (C) University of Manchester 2011-20 Peter Briggs, Ian Donaldson, Leo Zeef
+Copyright (C) University of Manchester 2011-20,2024 Peter Briggs,
+Ian Donaldson, Leo Zeef
 
 """
 
@@ -51,8 +52,6 @@ setup(
         'Operating System :: POSIX',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         "Programming Language :: Python :: 3",
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Updates related to the supported Python versions:

* Drops support for Python 2.7
* Updates the Github Python CI workflow to explicitly use `ubuntu-20.04` (rather than ubuntu-latest), in order to fix errors with Python 3.6 tests (since Python 3.6 is EOL and not supported by `ubuntu-22.04` - see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877).