### PR TITLE
Add option to compute distances from gene TES only ('--edge=tes')

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -58,9 +58,18 @@ example:
 .. image:: nearest_tss.png
    :align: center
 
-Alternatively distances can be calculated as the shortest distance
-between either of the peak edges to either the TSS or the TES of
-the gene, by specifying the ``--edge=both`` option::
+(This behaviour can be made explicit by specifying the
+``--edge=tss`` option.)
+
+Alternatively distances can be calculated as the distance from
+the gene TES (by specifying the ``--edge=tes``), or as the shortest
+distance between either of the peak edges to whichever of the TSS or
+the TES of the gene is closest (by specifying the ``--edge=both``
+option).
+
+For example:
+
+::
 
     RnaChipIntegrator --edge=both GENES PEAKS
 

--- a/rnachipintegrator/analysis.py
+++ b/rnachipintegrator/analysis.py
@@ -1,8 +1,8 @@
 #!/bin/env python
 #
 #     analysis.py: analyses of peaks vs features and vice versa
-#     Copyright (C) University of Manchester 2011-2019 Peter Briggs, Leo Zeef
-#     & Ian Donaldson
+#     Copyright (C) University of Manchester 2011-2019,2024 Peter Briggs,
+#     Leo Zeef & Ian Donaldson
 #
 """
 analysis.py
@@ -161,7 +161,23 @@ def sort_features_by_tss_distances(peak,features):
     """
     features.features = sorted(features.features,
                                key = lambda f:
-                               distances.tss_distances(peak,f))
+                               (distances.tss_distances(peak,f),f.id))
+
+def sort_features_by_tes_distances(peak,features):
+    """
+    Sort features by TES-to-edge distances to a peak
+
+    Arguments:
+      peak (Peak): peak instance
+      features (FeatureSet): set of features that will
+        be sorted into order according to the smallest
+        distance of their TES positions to the edges of
+        the peak. The sorting is done in place.
+
+    """
+    features.features = sorted(features.features,
+                               key = lambda f:
+                               (distances.tes_distances(peak,f),f.id))
 
 def sort_peaks_by_edge_distances(feature,peaks):
     """
@@ -194,3 +210,19 @@ def sort_peaks_by_tss_distances(feature,peaks):
     peaks.peaks = sorted(peaks.peaks,
                          key = lambda p:
                          distances.tss_distances(p,feature))
+
+def sort_peaks_by_tes_distances(feature,peaks):
+    """
+    Sort peaks by edge-to-TES distances to a feature
+
+    Arguments:
+      feature (Feature): feature instance
+      peaks (PeakSet): set of peaks that will be
+        sorted into order according to the smallest
+        distance of their edges from the TES position
+        of the feature. The sorting is done in place.
+
+    """
+    peaks.peaks = sorted(peaks.peaks,
+                         key = lambda p:
+                         distances.tes_distances(p,feature))

--- a/rnachipintegrator/distances.py
+++ b/rnachipintegrator/distances.py
@@ -1,8 +1,8 @@
 #!/bin/env python
 #
 #     distances.py: functions for determining distances and overlaps
-#     Copyright (C) University of Manchester 2011-2019 Peter Briggs, Leo Zeef
-#     & Ian Donaldson
+#     Copyright (C) University of Manchester 2011-2019,2024 Peter Briggs,
+#     Leo Zeef & Ian Donaldson
 #
 """
 distances.py
@@ -217,6 +217,40 @@ def tss_distances(peak,feature):
              abs(feature.tss - peak.end)]
     d_tss.sort()
     return tuple(d_tss)
+
+def tes_distances(peak,feature):
+    """
+    Return distances between peak edges and feature TES
+
+    Arguments:
+      peak (Peak): peak instance
+      feature (Feature): feature instance
+
+    Returns:
+      tuple: a pair of distances, the first being the
+        smallest distance between an edge of the peak
+        region to the TES of the feature region, and
+        the second being the distance from the other peak
+        edge to the TES.
+        If the TES position is entirely contained within
+        the peak then the smallest distance is returned as
+        zero, the second is the average of the distances
+        to the two peak edges from the TES.
+
+    """
+    # TES is considered as a point
+    if (feature.tes >= peak.start and
+        feature.tes <= peak.end):
+        # TES entirely contained in the peak
+        # Rank using the average distance of the peak
+        # edges from the TES
+        return (0,(abs(feature.tes - peak.start) +
+                   abs(feature.tes - peak.end))/2)
+    # Possible distances to TES
+    d_tes = [abs(feature.tes - peak.start),
+             abs(feature.tes - peak.end)]
+    d_tes.sort()
+    return tuple(d_tes)
 
 def distance_closest_edge(peak,feature):
     """

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -162,7 +162,7 @@ class TestFindNearestFeaturesForSummits(unittest.TestCase):
         # Run the analysis
         results = list(find_nearest_features(self.summits,
                                              self.features,
-                                             tss_only=True))
+                                             use_edge="TSS"))
         # Correct number of results
         self.assertEqual(len(results),5)
         # TSS distances for 1st peak
@@ -245,6 +245,100 @@ class TestFindNearestFeaturesForSummits(unittest.TestCase):
         # CG13051-RA  3239874
         # CG14448-RA  3283489
         # CG9130-RB  18246028
+        peak,features = results[4]
+        self.assertEqual(peak,Peak('chr3L','19498040','19498041'))
+        self.assertEqual(len(features),3)
+        self.assertEqual(features[0].id,'CG13051-RA')
+        self.assertEqual(features[1].id,'CG14448-RA')
+        self.assertEqual(features[2].id,'CG9130-RB')
+
+    def test_find_nearest_features_summits_tes_only(self):
+        # Run the analysis
+        results = list(find_nearest_features(self.summits,
+                                             self.features,
+                                             use_edge="TES"))
+        # Correct number of results
+        self.assertEqual(len(results),5)
+        # TES distances for 1st summit
+        # CG31973     41409
+        # CG2674-RC   47621
+        # CG2674-RE   47621
+        # CG2674-RA   47621
+        # CG3625-RA  216573
+        # CG3625-RB  216573
+        # CG3625-RC  216573
+        # CG2762-RA  473730
+        # CG17941-RA 573209
+        peak,features = results[0]
+        self.assertEqual(peak,Peak('chr2L','66811','66812'))
+        self.assertEqual(len(features),9)
+        self.assertEqual(features[0].id,'CG31973')
+        self.assertEqual(features[1].id,'CG2674-RA')
+        self.assertEqual(features[2].id,'CG2674-RC')
+        self.assertEqual(features[3].id,'CG2674-RE')
+        self.assertEqual(features[4].id,'CG3625-RA')
+        self.assertEqual(features[5].id,'CG3625-RB')
+        self.assertEqual(features[6].id,'CG3625-RC')
+        self.assertEqual(features[7].id,'CG2762-RA')
+        self.assertEqual(features[8].id,'CG17941-RA')
+        # TSS distances for 2nd summit
+        # CG3625-RA   34207
+        # CG3625-RB   34207
+        # CG3625-RC   34207
+        # CG2674-RC  134744
+        # CG2674-RE  134744
+        # CG2674-RA  134744
+        # CG31973    223775
+        # CG2762-RA  291364
+        # CG17941-RA 390843
+        peak,features = results[1]
+        self.assertEqual(peak,Peak('chr2L','249177','249178'))
+        self.assertEqual(len(features),9)
+        self.assertEqual(features[0].id,'CG3625-RA')
+        self.assertEqual(features[1].id,'CG3625-RB')
+        self.assertEqual(features[2].id,'CG3625-RC')
+        self.assertEqual(features[3].id,'CG2674-RA')
+        self.assertEqual(features[4].id,'CG2674-RC')
+        self.assertEqual(features[5].id,'CG2674-RE')
+        self.assertEqual(features[6].id,'CG31973')
+        self.assertEqual(features[7].id,'CG2762-RA')
+        self.assertEqual(features[8].id,'CG17941-RA')
+        # TSS distances for 3rd summit
+        # CG17941-RA  34070
+        # CG2762-RA   65408
+        # CG3625-RA  322565
+        # CG3625-RB  322565
+        # CG3625-RC  322565
+        # CG2674-RC  491517
+        # CG2674-RE  491517
+        # CG2674-RA  491517
+        # CG31973    580548
+        peak,features = results[2]
+        self.assertEqual(peak,Peak('chr2L','605950','605951'))
+        self.assertEqual(len(features),9)
+        self.assertEqual(features[0].id,'CG17941-RA')
+        self.assertEqual(features[1].id,'CG2762-RA')
+        self.assertEqual(features[2].id,'CG3625-RA')
+        self.assertEqual(features[3].id,'CG3625-RB')
+        self.assertEqual(features[4].id,'CG3625-RC')
+        self.assertEqual(features[5].id,'CG2674-RA')
+        self.assertEqual(features[6].id,'CG2674-RC')
+        self.assertEqual(features[7].id,'CG2674-RE')
+        self.assertEqual(features[8].id,'CG31973')
+        # TSS distances for 4th summit
+        # CG9130-RB  1002200
+        # CG13051-RA 13999724
+        # CG14448-RA 20524164
+        peak,features = results[3]
+        self.assertEqual(peak,Peak('chr3L','2258189','2258190'))
+        self.assertEqual(len(features),3)
+        self.assertEqual(features[0].id,'CG9130-RB')
+        self.assertEqual(features[1].id,'CG13051-RA')
+        self.assertEqual(features[2].id,'CG14448-RA')
+        # TSS distances for 5th peak
+        # CG13051-RA  3240126
+        # CG14448-RA  3284313
+        # CG9130-RB  18242051
         peak,features = results[4]
         self.assertEqual(peak,Peak('chr3L','19498040','19498041'))
         self.assertEqual(len(features),3)
@@ -508,7 +602,7 @@ class TestFindNearestFeaturesForRegions(unittest.TestCase):
         # Run the analysis
         results = list(find_nearest_features(self.peaks,
                                              self.features,
-                                             tss_only=True))
+                                             use_edge="TSS"))
         # Correct number of results
         self.assertEqual(len(results),5)
         # Closest distances for 1st peak
@@ -591,6 +685,100 @@ class TestFindNearestFeaturesForRegions(unittest.TestCase):
         # CG13051-RA  3239774
         # CG14448-RA  3283399
         # CG9130-RB  18245928
+        peak,features = results[4]
+        self.assertEqual(peak,Peak('chr3L','19497940','19498140'))
+        self.assertEqual(len(features),3)
+        self.assertEqual(features[0].id,'CG13051-RA')
+        self.assertEqual(features[1].id,'CG14448-RA')
+        self.assertEqual(features[2].id,'CG9130-RB')
+
+    def test_find_nearest_features_regions_tes_only(self):
+        # Run the analysis
+        results = list(find_nearest_features(self.peaks,
+                                             self.features,
+                                             use_edge="TES"))
+        # Correct number of results
+        self.assertEqual(len(results),5)
+        # Closest distances for 1st peak
+        # CG31973     41309
+        # CG2674-RC   47522
+        # CG2674-RE   47522
+        # CG2674-RA   47522
+        # CG3625-RA  216474
+        # CG3625-RB  216474
+        # CG3625-RC  216474
+        # CG2762-RA  473631
+        # CG17941-RA 573110
+        peak,features = results[0]
+        self.assertEqual(peak,Peak('chr2L','66711','66911'))
+        self.assertEqual(len(features),9)
+        self.assertEqual(features[0].id,'CG31973')
+        self.assertEqual(features[1].id,'CG2674-RA')
+        self.assertEqual(features[2].id,'CG2674-RC')
+        self.assertEqual(features[3].id,'CG2674-RE')
+        self.assertEqual(features[4].id,'CG3625-RA')
+        self.assertEqual(features[5].id,'CG3625-RB')
+        self.assertEqual(features[6].id,'CG3625-RC')
+        self.assertEqual(features[7].id,'CG2762-RA')
+        self.assertEqual(features[8].id,'CG17941-RA')
+        # Closest distances for 2nd peak
+        # CG3625-RA   34108
+        # CG3625-RB   34108
+        # CG3625-RC   34108
+        # CG2674-RC  134644
+        # CG2674-RE  134644
+        # CG2674-RA  134644
+        # CG31973    223675
+        # CG2762-RA  291265
+        # CG17941-RA 390744
+        peak,features = results[1]
+        self.assertEqual(peak,Peak('chr2L','249077','249277'))
+        self.assertEqual(len(features),9)
+        self.assertEqual(features[0].id,'CG3625-RA')
+        self.assertEqual(features[1].id,'CG3625-RB')
+        self.assertEqual(features[2].id,'CG3625-RC')
+        self.assertEqual(features[3].id,'CG2674-RA')
+        self.assertEqual(features[4].id,'CG2674-RC')
+        self.assertEqual(features[5].id,'CG2674-RE')
+        self.assertEqual(features[6].id,'CG31973')
+        self.assertEqual(features[7].id,'CG2762-RA')
+        self.assertEqual(features[8].id,'CG17941-RA')
+        # Closest distances for 3rd peak
+        # CG17941-RA  33971
+        # CG2762-RA   65308
+        # CG3625-RA  322465
+        # CG3625-RB  322465
+        # CG3625-RC  322465
+        # CG2674-RC  491417
+        # CG2674-RE  491417
+        # CG2674-RA  491417
+        # CG31973    580448
+        peak,features = results[2]
+        self.assertEqual(peak,Peak('chr2L','605850','606050'))
+        self.assertEqual(len(features),9)
+        self.assertEqual(features[0].id,'CG17941-RA')
+        self.assertEqual(features[1].id,'CG2762-RA')
+        self.assertEqual(features[2].id,'CG3625-RA')
+        self.assertEqual(features[3].id,'CG3625-RB')
+        self.assertEqual(features[4].id,'CG3625-RC')
+        self.assertEqual(features[5].id,'CG2674-RA')
+        self.assertEqual(features[6].id,'CG2674-RC')
+        self.assertEqual(features[7].id,'CG2674-RE')
+        self.assertEqual(features[8].id,'CG31973')
+        # Closest distances for 4th peak
+        # CG9130-RB   1002100
+        # CG13051-RA 13999624
+        # CG14448-RA 20524064
+        peak,features = results[3]
+        self.assertEqual(peak,Peak('chr3L','2258089','2258290'))
+        self.assertEqual(len(features),3)
+        self.assertEqual(features[0].id,'CG9130-RB')
+        self.assertEqual(features[1].id,'CG13051-RA')
+        self.assertEqual(features[2].id,'CG14448-RA')
+        # Closest distances for 5th peak
+        # CG13051-RA  3240026
+        # CG14448-RA  3284214
+        # CG9130-RB  18241951
         peak,features = results[4]
         self.assertEqual(peak,Peak('chr3L','19497940','19498140'))
         self.assertEqual(len(features),3)
@@ -877,7 +1065,7 @@ class TestFindNearestPeaksForSummits(unittest.TestCase):
         # Run the analysis
         results = list(find_nearest_peaks(self.features,
                                           self.summits,
-                                          tss_only=True))
+                                          use_edge="TSS"))
         # Convenience variables for summits
         summits = (Peak('chr2L','66811','66812'),
                    Peak('chr2L','249177','249178'),
@@ -984,6 +1172,126 @@ class TestFindNearestPeaksForSummits(unittest.TestCase):
         # #2   108919
         # #1   465692
         # #0   648058
+        feature,peaks = results[8]
+        self.assertEqual(feature,Feature('CG17941-RA',
+                                         'chr2L','640021','714969','-'))
+        expected = PeakSet()
+        expected.addPeak(summits[2])
+        expected.addPeak(summits[1])
+        expected.addPeak(summits[0])
+        self.assertEqual(peaks,expected)
+
+    def test_find_nearest_peaks_summits_tes_only(self):
+        # Run the analysis
+        results = list(find_nearest_peaks(self.features,
+                                          self.summits,
+                                          use_edge="TES"))
+        # Convenience variables for summits
+        summits = (Peak('chr2L','66811','66812'),
+                   Peak('chr2L','249177','249178'),
+                   Peak('chr2L','605950','605951'))
+        # Correct number of results
+        self.assertEqual(len(results),12)
+        # Closest distances for 1st feature
+        # #0   41409
+        # #1  223775
+        # #2  580548
+        feature,peaks = results[0]
+        self.assertEqual(feature,Feature('CG31973',
+                                         'chr2L','25402','59243','-'))
+        expected = PeakSet()
+        expected.addPeak(summits[0])
+        expected.addPeak(summits[1])
+        expected.addPeak(summits[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 2nd feature
+        # #0   47621
+        # #1  134744
+        # #2  491517
+        feature,peaks = results[1]
+        self.assertEqual(feature,Feature('CG2674-RC',
+                                         'chr2L','107926','114433','+'))
+        expected = PeakSet()
+        expected.addPeak(summits[0])
+        expected.addPeak(summits[1])
+        expected.addPeak(summits[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 3rd feature
+        # #0   47621
+        # #1  134744
+        # #2  491517
+        feature,peaks = results[2]
+        self.assertEqual(feature,Feature('CG2674-RE',
+                                         'chr2L','106903','114433','+'))
+        expected = PeakSet()
+        expected.addPeak(summits[0])
+        expected.addPeak(summits[1])
+        expected.addPeak(summits[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 4th feature
+        # #0   47621
+        # #1  134744
+        # #2  491517
+        feature,peaks = results[3]
+        self.assertEqual(feature,Feature('CG2674-RA',
+                                         'chr2L','107760','114433','+'))
+        expected = PeakSet()
+        expected.addPeak(summits[0])
+        expected.addPeak(summits[1])
+        expected.addPeak(summits[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 5th feature
+        # #1   34207
+        # #0  216573
+        # #2  322565
+        feature,peaks = results[4]
+        self.assertEqual(feature,Feature('CG3625-RA',
+                                         'chr2L','283385','286528','-'))
+        expected = PeakSet()
+        expected.addPeak(summits[1])
+        expected.addPeak(summits[0])
+        expected.addPeak(summits[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 6th feature
+        # #1   34207
+        # #0  216573
+        # #2  322565
+        feature,peaks = results[5]
+        self.assertEqual(feature,Feature('CG3625-RB',
+                                         'chr2L','283385','285777','-'))
+        expected = PeakSet()
+        expected.addPeak(summits[1])
+        expected.addPeak(summits[0])
+        expected.addPeak(summits[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 7th feature
+        # #1   34207
+        # #0  216573
+        # #2  322565
+        feature,peaks = results[6]
+        self.assertEqual(feature,Feature('CG3625-RC',
+                                         'chr2L','283385','291011','-'))
+        expected = PeakSet()
+        expected.addPeak(summits[1])
+        expected.addPeak(summits[0])
+        expected.addPeak(summits[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 8th feature
+        # #2    65408
+        # #1   291364
+        # #0   473730
+        feature,peaks = results[7]
+        self.assertEqual(feature,Feature('CG2762-RA',
+                                         'chr2L','523467','540542','+'))
+        expected = PeakSet()
+        expected.addPeak(summits[2])
+        expected.addPeak(summits[1])
+        expected.addPeak(summits[0])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 9th feature
+        # #2    34070
+        # #1   390843
+        # #0   573209
         feature,peaks = results[8]
         self.assertEqual(feature,Feature('CG17941-RA',
                                          'chr2L','640021','714969','-'))
@@ -1286,7 +1594,7 @@ class TestFindNearestPeaksForRegions(unittest.TestCase):
         # Run the analysis
         results = list(find_nearest_peaks(self.features,
                                           self.peaks,
-                                          tss_only=True))
+                                          use_edge="TSS"))
         # Convenience variables for summits
         peaks_ = (Peak('chr2L','66711','66911'),
                   Peak('chr2L','249077','249277'),
@@ -1393,6 +1701,126 @@ class TestFindNearestPeaksForRegions(unittest.TestCase):
         # #2   108919
         # #1   465692
         # #0   648058
+        feature,peaks = results[8]
+        self.assertEqual(feature,Feature('CG17941-RA',
+                                         'chr2L','640021','714969','-'))
+        expected = PeakSet()
+        expected.addPeak(peaks_[2])
+        expected.addPeak(peaks_[1])
+        expected.addPeak(peaks_[0])
+        self.assertEqual(peaks,expected)
+
+    def test_find_nearest_peaks_regions_tes_only(self):
+        # Run the analysis
+        results = list(find_nearest_peaks(self.features,
+                                          self.peaks,
+                                          use_edge="TES"))
+        # Convenience variables for summits
+        peaks_ = (Peak('chr2L','66711','66911'),
+                  Peak('chr2L','249077','249277'),
+                  Peak('chr2L','605850','606050'))
+        # Correct number of results
+        self.assertEqual(len(results),12)
+        # Closest TES distances for 1st feature
+        # #0   41309
+        # #1  223675
+        # #2  580448
+        feature,peaks = results[0]
+        self.assertEqual(feature,Feature('CG31973',
+                                         'chr2L','25402','59243','-'))
+        expected = PeakSet()
+        expected.addPeak(peaks_[0])
+        expected.addPeak(peaks_[1])
+        expected.addPeak(peaks_[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 2nd feature
+        # #0   47522
+        # #1  134644
+        # #2  491417
+        feature,peaks = results[1]
+        self.assertEqual(feature,Feature('CG2674-RC',
+                                         'chr2L','107926','114433','+'))
+        expected = PeakSet()
+        expected.addPeak(peaks_[0])
+        expected.addPeak(peaks_[1])
+        expected.addPeak(peaks_[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 3rd feature
+        # #0   47522
+        # #1  134644
+        # #2  491417
+        feature,peaks = results[2]
+        self.assertEqual(feature,Feature('CG2674-RE',
+                                         'chr2L','106903','114433','+'))
+        expected = PeakSet()
+        expected.addPeak(peaks_[0])
+        expected.addPeak(peaks_[1])
+        expected.addPeak(peaks_[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 4th feature
+        # #0   47522
+        # #1  134644
+        # #2  491417
+        feature,peaks = results[3]
+        self.assertEqual(feature,Feature('CG2674-RA',
+                                         'chr2L','107760','114433','+'))
+        expected = PeakSet()
+        expected.addPeak(peaks_[0])
+        expected.addPeak(peaks_[1])
+        expected.addPeak(peaks_[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 5th feature
+        # #1   34108
+        # #0  216474
+        # #2  322465
+        feature,peaks = results[4]
+        self.assertEqual(feature,Feature('CG3625-RA',
+                                         'chr2L','283385','286528','-'))
+        expected = PeakSet()
+        expected.addPeak(peaks_[1])
+        expected.addPeak(peaks_[0])
+        expected.addPeak(peaks_[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 6th feature
+        # #1   34108
+        # #0  216474
+        # #2  322465
+        feature,peaks = results[5]
+        self.assertEqual(feature,Feature('CG3625-RB',
+                                         'chr2L','283385','285777','-'))
+        expected = PeakSet()
+        expected.addPeak(peaks_[1])
+        expected.addPeak(peaks_[0])
+        expected.addPeak(peaks_[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 7th feature
+        # #1    34108
+        # #0   216474
+        # #2   322465
+        feature,peaks = results[6]
+        self.assertEqual(feature,Feature('CG3625-RC',
+                                         'chr2L','283385','291011','-'))
+        expected = PeakSet()
+        expected.addPeak(peaks_[1])
+        expected.addPeak(peaks_[0])
+        expected.addPeak(peaks_[2])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 8th feature
+        # #2    65308
+        # #1   291265
+        # #0   473631
+        feature,peaks = results[7]
+        self.assertEqual(feature,Feature('CG2762-RA',
+                                         'chr2L','523467','540542','+'))
+        expected = PeakSet()
+        expected.addPeak(peaks_[2])
+        expected.addPeak(peaks_[1])
+        expected.addPeak(peaks_[0])
+        self.assertEqual(peaks,expected)
+        # Closest distances for 9th feature
+        # #2    33971
+        # #1   390744
+        # #0   573110
         feature,peaks = results[8]
         self.assertEqual(feature,Feature('CG17941-RA',
                                          'chr2L','640021','714969','-'))

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -183,19 +183,19 @@ class TestAnalysisParams(unittest.TestCase):
         self.assertEqual(params.peaks,None)
         self.assertEqual(params.genes,None)
         self.assertEqual(params.cutoff,None)
-        self.assertFalse(params.tss_only)
+        self.assertEqual(params.use_edge,"BOTH")
         self.assertFalse(params.only_differentially_expressed)
 
     def test_set_values(self):
         params = AnalysisParams(peaks="peaks",
                                 genes="genes",
                                 cutoff=100000,
-                                tss_only=True,
+                                use_edge="TSS",
                                 only_differentially_expressed=True)
         self.assertEqual(params.peaks,"peaks")
         self.assertEqual(params.genes,"genes")
         self.assertEqual(params.cutoff,100000)
-        self.assertTrue(params.tss_only)
+        self.assertEqual(params.use_edge,"TSS")
         self.assertTrue(params.only_differentially_expressed)
 
 class TestBatchNamer(unittest.TestCase):

--- a/test/test_distances.py
+++ b/test/test_distances.py
@@ -1,6 +1,6 @@
 #
 #     test_analysis.py: unit tests for analysis module
-#     Copyright (C) University of Manchester 2011-5 Peter Briggs
+#     Copyright (C) University of Manchester 2011-5,2024 Peter Briggs
 
 from common import *
 from rnachipintegrator.Peaks import Peak
@@ -9,6 +9,7 @@ from rnachipintegrator.distances import regions_overlap
 from rnachipintegrator.distances import closestDistanceToRegion
 from rnachipintegrator.distances import edge_distances
 from rnachipintegrator.distances import tss_distances
+from rnachipintegrator.distances import tes_distances
 from rnachipintegrator.distances import direction
 import unittest
 
@@ -158,6 +159,35 @@ class TestTSSDistancesFunction(unittest.TestCase):
                          (0,75))
         self.assertEqual(tss_distances(Peak('chr1','250','350'),
                                        Feature('NM4','chr1','200','300','-')),
+                         (0,50))
+
+########################################################################
+#
+# TestTESDistancesFunction
+#
+#########################################################################
+
+class TestTESDistancesFunction(unittest.TestCase):
+    def test_tes_distances_peak_before_TES(self):
+        self.assertEqual(tes_distances(Peak('chr1','100','200'),
+                                       Feature('NM1','chr1','250','400','+')),
+                         (200,300))
+        self.assertEqual(tes_distances(Peak('chr1','100','200'),
+                                       Feature('NM1','chr1','250','400','-')),
+                         (50,150))
+    def test_tes_distances_TES_before_peak(self):
+        self.assertEqual(tes_distances(Peak('chr1','250','400'),
+                                       Feature('NM2','chr1','100','200','+')),
+                         (50,200))
+        self.assertEqual(tes_distances(Peak('chr1','250','400'),
+                                       Feature('NM2','chr1','100','200','-')),
+                         (150,300))
+    def test_tes_distances_peak_contains_TES(self):
+        self.assertEqual(tes_distances(Peak('chr1','100','250'),
+                                       Feature('NM3','chr1','50','200','+')),
+                         (0,75))
+        self.assertEqual(tes_distances(Peak('chr1','250','350'),
+                                       Feature('NM4','chr1','300','400','-')),
                          (0,50))
 
 ########################################################################


### PR DESCRIPTION
Updates the `--edge` option to allow the user to specify gene TES as the reference point for calculating distances to peaks (similar to the existing option to specify the TSS).

As well as changes to the CLI to add `tes` as a valid option for the `--edge` argument, the underlying code has been modified to enable this additional. Specifically the `find_nearest_features` and `find_nearest_peaks` functions no longer support the boolean `tss_only` argument, instead it has been replaced by the `use_edge` argument (which must be a string with one of `tss`, `tes` or `both`).