### PR TITLE
Update configuration for building documentation on ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+python:
+  install:
+    - requirements: requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
Adds a `.readthedocs.yaml` configuration file for building documentation on ReadTheDocs, to fix build errors.