### PR TITLE
Update documentation to add the ReadTheDocs theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,5 +12,6 @@ build:
 python:
   install:
     - requirements: requirements.txt
+    - requirements: docs/requirements.txt
     - method: pip
       path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,9 @@ sys.path.append('../')
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['sphinx_rtd_theme',
+              'sphinx.ext.autodoc',
+              'sphinx.ext.intersphinx',]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -95,7 +97,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==7.1.2
+sphinx_rtd_theme==2.0.0
+readthedocs-sphinx-search==0.3.2


### PR DESCRIPTION
Updates the documentation configuration to explicitly specify the default theme from ReadTheDocs (RTD):

https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html