### PR TITLE
Add Github workflow to publish to PyPI and TestPyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,95 @@
+# Workflow to build and publish RnaChipIntegrator to PyPI and TestPyPI
+#
+# - TestPyPI publication only on push to 'devel' branch
+# - PyPI publication only for releases
+#
+# Based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+#
+# See e.g.
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags
+# for syntax for selecting branches for 'on'
+
+name: Publish Python distribution package to PyPI and TestPyPI
+
+on: push
+  branches:
+    - 'devel'
+    - 'releases/**'
+
+jobs:
+  # Build the distribution for publication
+  build:
+    name: Build distribution package
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  # Publish to PyPI
+  publish-to-pypi:
+    name: Publish Python distribution package to PyPI
+    # Only publish to PyPI on release tag pushes
+    if: startsWith(github.ref, 'refs/releases/')
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/RnaChipIntegrator
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Publish to TestPyPI
+  publish-to-testpypi:
+    name: Publish Python distribution package to TestPyPI
+    # Should run on all pushes to 'devel' and on release
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/RnaChipIntegrator
+    permissions:
+      # IMPORTANT: mandatory for trusted publishing
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,8 +11,9 @@
 
 name: Publish Python distribution package to PyPI and TestPyPI
 
-on: push
-  branches:
+on:
+  push:
+    branches:
     - 'devel'
     - 'releases/**'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "RnaChipIntegrator"
-dynamic = ["version"]
+dynamic = [
+  "version",
+  "description",
+  "readme",
+  "license",
+  "authors",
+  "maintainers",
+  "keywords",
+  "classifiers",
+  "scripts",
+  "dependencies"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "RnaChipIntegrator"
+dynamic = ["version"]

--- a/setup.py
+++ b/setup.py
@@ -1,39 +1,47 @@
-"""Description
-
-Setup script to install RnaChipIntegrator: analyses of peak data with
-genomic feature data
-
-Copyright (C) University of Manchester 2011-20,2024 Peter Briggs,
-Ian Donaldson, Leo Zeef
-
+"""
+Setup script to install RnaChipIntegrator (analyses of peak data with
+genomic feature data)
 """
 
 from setuptools import setup
-import rnachipintegrator
+import codecs
+import os.path
 
-# Package version
-version = rnachipintegrator.get_version()
+# Installation requirements
+install_requires = ['xlsxwriter >= 0.8.4']
 
-download_url = 'https://github.com/fls-bioinformatics-core/RnaChipIntegrator/archive/v' + version + '.tar.gz'
+# Acquire package version for installation
+# (see https://packaging.python.org/guides/single-sourcing-package-version/)
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
 
-with open('README.rst') as fh:
-    readme = fh.read()
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
 
-# Hack to acquire all scripts that we want to
-# install into 'bin'
-from glob import glob
-scripts = []
-for pattern in ('bin/*.py',):
-    scripts.extend(glob(pattern))
+RNACHIPINTEGRATOR_VERSION = get_version("rnachipintegrator/__init__.py")
+
+DOWNLOAD_URL = "https://github.com/fls-bioinformatics-core/"\
+               "RnaChipIntegrator/archive/v%s.tar.gz" %\
+               RNACHIPINTEGRATOR_VERSION
+
+# Get long description from the project README
+readme = read('README.rst')
 
 # Setup for installation etc
 setup(
     name = "RnaChipIntegrator",
-    version = version,
+    version = RNACHIPINTEGRATOR_VERSION,
     description = "Analyse genes against peak data, and vice versa",
     long_description = readme,
     url = 'https://github.com/fls-bioinformatics-core/RnaChipIntegrator',
-    download_url = download_url,
+    download_url = DOWNLOAD_URL,
     author = 'Peter Briggs, Ian Donaldson, Leo Zeef',
     author_email = 'peter.briggs@manchester.ac.uk',
     maintainer = 'Peter Briggs',
@@ -53,16 +61,14 @@ setup(
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'Natural Language :: English',
         "Programming Language :: Python :: 3",
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    install_requires = ['xlsxwriter >= 0.8.4',],
+    install_requires = install_requires,
     test_suite = 'nose.collector',
     tests_require = ['nose'],
-    scripts = scripts,
     data_files = [ ('RnaChipIntegrator',
                     ['README.rst',
                      'LICENSE',


### PR DESCRIPTION
PyPI and TestPyPI now require a "trusted publisher" for uploading new or updated distribution packages, so this PR adds a Github workflow to address this.

The workflow should upload pushes to the `devel` branch to TestPyPI, and releases to PyPI and is based on the relevant Python Packaging User Guide section (https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#) with some modifications.

Also adds a `pyproject.toml` file and updates `setup.py` accordingly.