### PR TITLE
Fix publication workflow for TestPyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,6 @@
 # Workflow to build and publish RnaChipIntegrator to PyPI and TestPyPI
 #
-# - TestPyPI publication only on push to 'devel' branch
+# - TestPyPI publication only on tagging
 # - PyPI publication only for releases
 #
 # Based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
@@ -14,7 +14,7 @@ name: Publish Python distribution package to PyPI and TestPyPI
 on:
   push:
     branches:
-    - 'devel'
+    - 'tags/**'
     - 'releases/**'
 
 jobs:
@@ -70,7 +70,8 @@ jobs:
   # Publish to TestPyPI
   publish-to-testpypi:
     name: Publish Python distribution package to TestPyPI
-    # Should run on all pushes to 'devel' and on release
+    # Should run on all tag pushes
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the publication workflow so that upload to TestPyPI only runs on tag pushes, to try and fix an issue with duplicated version numbers on the previous iteration of the workflow.

Essentially neither PyPI nor test PyPI allow the same version number to be reused, so publication will fail if the version hasn't been updated within the repository when the workflow is triggered. For releases a new version number should be guaranteed so we don't expect to hit this issue, however for general pushes (e.g. to fix a bug or add a new feature) this is not usually the case.

A compromise is to publish to TestPyPI on tag pushes, which we could reasonably expect to be accompanied by a version number change (although again this is not guaranteed so could still fail). Non-release tags should perhaps be of the form of "alpha" or "release-candidate" versions, e.g. `3.0.0a1` or `3.0.0rc1` etc (see https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#choosing-a-versioning-scheme).