### PR TITLE
Fix publication to TestPyPI on tag push

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,8 +14,9 @@ name: Publish Python distribution package to PyPI and TestPyPI
 on:
   push:
     branches:
-    - 'tags/**'
     - 'releases/**'
+    tags:
+    - 'v*'
 
 jobs:
   # Build the distribution for publication


### PR DESCRIPTION
Another attempt to fix triggering publication to TestPyPI on tag pushes in the `publish-to-pypi.yml` workflow, by changing how tags are specified in the YAML file.