### PR TITLE
Update CITATION.cff with Zenodo DOI for RnaChipIntegrator 3.0.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,6 +25,9 @@ identifiers:
   - description: "Archived snapshots of all versions of RnaChipIntegrator"
     type: doi
     value: 10.5281/zenodo.592255
+  - description: "Archived snapshot of version 3.0.0 of RnaChipIntegrator"
+    type: doi
+    value: 10.5281/zenodo.10623997
   - description: "Archived snapshot of version 1.0.2 of RnaChipIntegrator"
     type: doi
     value: 10.5281/zenodo.60362


### PR DESCRIPTION
Updates the `CITATION.cff` file to include the Zenodo DOI for RnaChipIntegrator version 3.0.0 (which couldn't be created until a release was created on GitHub).